### PR TITLE
chore: update Docker Hub registry and image names

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,8 +11,8 @@ on:
 env:
   REGISTRY: docker.io
   # Using distinct names for Docker Hub repositories
-  SERVER_IMAGE: cnjax/code-together-server
-  MANAGER_IMAGE: cnjax/code-together-manager
+  SERVER_IMAGE: genewoo/ai-together-server
+  MANAGER_IMAGE: genewoo/ai-together-manager
 
 permissions:
   contents: read

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -444,13 +444,13 @@ lsof -ti:8080 | xargs kill -9
 
 ### Images
 
-- **Image:** `cnjax/code-together-manager`
+- **Image:** `genewoo/ai-together-manager`
 - **Tag:** `latest` (or specific version tags like `v1.0.0`)
 - **Port:** `80` (Internal Nginx port)
 
 ### Server
 
-- **Image:** `cnjax/code-together-server`
+- **Image:** `genewoo/ai-together-server`
 
 ### PostgreSQL
 - **Image:** `postgres:latest`

--- a/DOCKER_CN.md
+++ b/DOCKER_CN.md
@@ -121,12 +121,12 @@ sudo systemctl restart docker
 
    ```bash
    # 在可访问 Docker Hub 的服务器上
-   docker pull cnjax/code-together-server:latest
-   docker pull cnjax/code-together-manager:latest
+   docker pull genewoo/ai-together-server:latest
+   docker pull genewoo/ai-together-manager:latest
 
    # 保存为文件
-   docker save cnjax/code-together-server:latest | gzip > server.tar.gz
-   docker save cnjax/code-together-manager:latest | gzip > manager.tar.gz
+   docker save genewoo/ai-together-server:latest | gzip > server.tar.gz
+   docker save genewoo/ai-together-manager:latest | gzip > manager.tar.gz
    ```
 
 ### 方案 4: 使用阿里云容器镜像服务（推荐中国用户）
@@ -146,14 +146,14 @@ sudo systemctl restart docker
 
 ```bash
 # 从 Docker Hub 拉取
-docker pull cnjax/code-together-server:latest
-docker pull cnjax/code-together-manager:latest
+docker pull genewoo/ai-together-server:latest
+docker pull genewoo/ai-together-manager:latest
 
 # 重新标记
-docker tag cnjax/code-together-server:latest \
+docker tag genewoo/ai-together-server:latest \
   registry.cn-hangzhou.aliyuncs.com/你的命名空间/server:latest
 
-docker tag cnjax/code-together-manager:latest \
+docker tag genewoo/ai-together-manager:latest \
   registry.cn-hangzhou.aliyuncs.com/你的命名空间/manager:latest
 
 # 推送到阿里云

--- a/Makefile
+++ b/Makefile
@@ -203,9 +203,9 @@ docs: ## Compile manuals to HTML
 .PHONY: docker docker-server docker-manager docker-push docker-push-server docker-push-manager
 
 DOCKER_TAG ?= latest
-DOCKER_REGISTRY ?= cnjax
-SERVER_IMAGE = $(DOCKER_REGISTRY)/code-together-server
-MANAGER_IMAGE = $(DOCKER_REGISTRY)/code-together-manager
+DOCKER_REGISTRY ?= genewoo
+SERVER_IMAGE = $(DOCKER_REGISTRY)/ai-together-server
+MANAGER_IMAGE = $(DOCKER_REGISTRY)/ai-together-manager
 
 docker: docker-server docker-manager ## Build all Docker images
 

--- a/docker-compose.cn.yml
+++ b/docker-compose.cn.yml
@@ -30,13 +30,13 @@ services:
 
   server:
     # 使用 docker.gh-proxy.com 代理 Docker Hub
-    # 原始地址: cnjax/code-together-server:latest
-    # 代理地址: docker.gh-proxy.com/cnjax/code-together-server:latest
+    # 原始地址: genewoo/ai-together-server:latest
+    # 代理地址: docker.gh-proxy.com/genewoo/ai-together-server:latest
     # 如果需要本地构建，取消注释以下几行并注释掉 image 行：
     # build:
     #   context: .
     #   dockerfile: ./server/Dockerfile
-    image: docker.gh-proxy.com/cnjax/code-together-server:${IMAGE_TAG:-latest}
+    image: docker.gh-proxy.com/genewoo/ai-together-server:${IMAGE_TAG:-latest}
     container_name: code-together-server
     restart: unless-stopped
     depends_on:
@@ -58,9 +58,9 @@ services:
 
   manager:
     # 使用 docker.gh-proxy.com 代理 Docker Hub
-    # 原始地址: cnjax/code-together-manager:latest
-    # 代理地址: docker.gh-proxy.com/cnjax/code-together-manager:latest
-    image: docker.gh-proxy.com/cnjax/code-together-manager:${IMAGE_TAG:-latest}
+    # 原始地址: genewoo/ai-together-manager:latest
+    # 代理地址: docker.gh-proxy.com/genewoo/ai-together-manager:latest
+    image: docker.gh-proxy.com/genewoo/ai-together-manager:${IMAGE_TAG:-latest}
     container_name: code-together-manager
     restart: unless-stopped
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@ services:
       retries: 5
 
   server:
-    image: cnjax/code-together-server:${IMAGE_TAG:-latest}
+    image: genewoo/ai-together-server:${IMAGE_TAG:-latest}
     container_name: code-together-server
     restart: unless-stopped
     depends_on:
@@ -42,7 +42,7 @@ services:
     # No external port mapping - only accessible via manager reverse proxy
 
   manager:
-    image: cnjax/code-together-manager:${IMAGE_TAG:-latest}
+    image: genewoo/ai-together-manager:${IMAGE_TAG:-latest}
     container_name: code-together-manager
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Summary

This PR updates all Docker image references to use the new registry (`genewoo`) and repository name (`ai-together`). This aligns the Docker configuration with the renamed repository from `code-together` to `ai-together`.

Additionally includes a fix for the manager Docker build that was failing with Vite entry module resolution error.

## Type of Change

- [x] **Refactoring** - Code change that neither fixes a bug nor adds a feature
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Performance
- [ ] Tests

## Related Issues

Related to workflow run #23125890144 (Docker Hub login failure due to incorrect registry)
Fixes job #67171856661 (Manager Docker build failure)

## Changes Made

### Docker Hub Registry Updates

List the specific changes made in this PR:

- Changed Docker Hub registry from `cnjax` to `genewoo`
- Renamed Docker images from `code-together-*` to `ai-together-*`
- Updated `.github/workflows/docker-publish.yml` with new image names
- Updated `docker-compose.prod.yml` with new image references
- Updated `docker-compose.cn.yml` with new image references
- Updated `Makefile` DOCKER_REGISTRY default and image names
- Updated documentation in `DOCKER.md`
- Updated documentation in `DOCKER_CN.md`

### Manager Docker Build Fix

**File:** `manager/tsconfig.json`

Fixed Vite build error "Could not resolve entry module 'index.html'" that was occurring in Docker builds.

- Removed custom `tsBuildInfoFile: "./node_modules/.tmp/tsconfig.app.tsbuildinfo"` from tsconfig.json
- The custom path was causing issues because `.dockerignore` excludes `node_modules`
- When `tsc -b` ran before Vite, it couldn't properly write to the excluded directory
- Letting TypeScript use the default build info location resolves the Docker build failure

## Testing

- [x] Unit tests pass locally (`make test`)
- [ ] Integration tests pass locally (`make integration-test`)
- [x] Manual testing performed (verified all image references updated)
- [ ] Added new tests for the changes
- [ ] All existing tests still pass

### Test Cases

Verified that all references to `cnjax/code-together-*` have been replaced with `genewoo/ai-together-*`:
- Workflow file: `.github/workflows/docker-publish.yml`
- Docker Compose files: `docker-compose.prod.yml`, `docker-compose.cn.yml`
- Build system: `Makefile`
- Documentation: `DOCKER.md`, `DOCKER_CN.md`

**Manager Docker build fix:**
- Removed problematic `tsBuildInfoFile` configuration
- Build now uses default TypeScript build info location
- Resolves Vite entry module resolution error in Docker context

## Prerequisites

Before merging, ensure these Docker Hub repositories exist:
- `genewoo/ai-together-server`
- `genewoo/ai-together-manager`

## Documentation

- [x] Updated relevant documentation (DOCKER.md, DOCKER_CN.md)
- [ ] Added comments to complex code sections
- [ ] Updated API documentation (if applicable)

## Breaking Changes

Users pulling from `cnjax/code-together-*` will need to update their configurations to use `genewoo/ai-together-*`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested my changes locally
- [x] I have updated the commit messages to follow semantic commit conventions

## Additional Notes

This change resolves the GitHub Actions workflow failure where the Docker Hub login was attempting to push to `cnjax` registry, which is not accessible with the configured `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets.

Additionally fixes the manager Docker build that was failing in job 67171856661 with:
```
error during build:
Could not resolve entry module "index.html".
```

The root cause was a custom `tsBuildInfoFile` path pointing to `./node_modules/.tmp/` which is excluded by `.dockerignore`, causing `tsc -b` to create invalid state before Vite runs.

After merging to `main`, the workflow will automatically:
- Build multi-platform Docker images (linux/amd64, linux/arm64)
- Push to Docker Hub under `genewoo/ai-together-server:latest` and `genewoo/ai-together-manager:latest`
- Tag images with commit SHA and version tags

## Commits Included

1. `d2f304c` - chore: update Docker Hub registry and image names
2. `1762a04` - build: remove garble binary obfuscation from build process
3. `b0c5ef7` - fix(manager): resolve Docker build Vite entry module error

## Reviewers

@reviewer1 @reviewer2