### PR TITLE
fix: rename 'Code Together' to 'AI Together' across codebase

### DIFF
--- a/.claude/agents/github-issue-investigator.md
+++ b/.claude/agents/github-issue-investigator.md
@@ -5,7 +5,7 @@ model: sonnet
 color: green
 ---
 
-You are an elite GitHub Issue Investigator and Resolver, specializing in systematic issue analysis, investigation, and resolution for the Code Together project. You combine deep technical expertise with methodical problem-solving to transform vague issue reports into well-understood problems with concrete solutions.
+You are an elite GitHub Issue Investigator and Resolver, specializing in systematic issue analysis, investigation, and resolution for the AI Together project. You combine deep technical expertise with methodical problem-solving to transform vague issue reports into well-understood problems with concrete solutions.
 
 ## Core Responsibilities
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ If applicable, add screenshots to help explain your problem.
 ## Environment
 
 - **OS**: [e.g. macOS 14, Windows 11, Ubuntu 22.04]
-- **Code Together Version**: [e.g. v1.0.0]
+- **AI Together Version**: [e.g. v1.0.0]
 - **AI Tool**: [e.g. Claude Code, Codex, OpenCode]
 - **Browser** (if applicable): [e.g. Chrome 120, Safari 17]
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ## Feature Description
 
-A clear and concise description of the feature you'd like to see added to Code Together.
+A clear and concise description of the feature you'd like to see added to AI Together.
 
 ## Use Case
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about Code Together
+about: Ask a question about AI Together
 title: '[QUESTION] '
 labels: question
 assignees: ''
@@ -21,7 +21,7 @@ Provide any relevant context that might help answer your question:
 ## Environment
 
 - **OS**: [e.g. macOS 14, Windows 11, Ubuntu 22.04]
-- **Code Together Version**: [e.g. v1.0.0]
+- **AI Together Version**: [e.g. v1.0.0]
 - **AI Tool**: [e.g. Claude Code, Codex, OpenCode]
 
 ## Additional Information

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ This project uses a three-tier documentation structure:
 
 ## Project Overview
 
-Code Together is a team collaboration platform for managing AI coding tools (Claude Code, Codex, and OpenCode). It provides centralized provider management, team-level settings, usage statistics, and automatic configuration distribution across team members.
+AI Together is a team collaboration platform for managing AI coding tools (Claude Code, Codex, and OpenCode). It provides centralized provider management, team-level settings, usage statistics, and automatic configuration distribution across team members.
 
 The system consists of four main components:
 1. **Server** (`server/`) - Backend API for centralized management, authentication, and usage tracking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Code Together
+# Contributing to AI Together
 
-Thank you for your interest in contributing to Code Together! We appreciate your help in making this project better.
+Thank you for your interest in contributing to AI Together! We appreciate your help in making this project better.
 
 ## Table of Contents
 
@@ -264,4 +264,4 @@ See [integration/INTEGRATION_TEST_SETUP.md](integration/INTEGRATION_TEST_SETUP.m
 - Start a [Discussion](https://github.com/shtdu/ai-together/discussions)
 - Read the [Documentation](README.md)
 
-Thank you for contributing to Code Together!
+Thank you for contributing to AI Together!

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,6 +1,6 @@
 # Docker Deployment Guide
 
-This guide explains how to deploy the complete Code Together platform (Server API + Manager UI) using Docker and Docker Compose.
+This guide explains how to deploy the complete AI Together platform (Server API + Manager UI) using Docker and Docker Compose.
 
 # 🇨🇳 中国用户专用部署
 
@@ -221,7 +221,7 @@ docker exec code-together-db pg_dump -U codetogether code_together > backup_$(da
 Create `backup.sh`:
 ```bash
 #!/bin/bash
-# Backup script for Code Together database
+# Backup script for AI Together database
 
 BACKUP_DIR="./backups"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)

--- a/DOCKER_CN.md
+++ b/DOCKER_CN.md
@@ -1,6 +1,6 @@
 # Docker 部署指南（中国用户）
 
-本指南专为中国用户提供 Code Together 平台的 Docker 部署说明。
+本指南专为中国用户提供 AI Together 平台的 Docker 部署说明。
 
 ## ⚠️ 网络连接问题
 
@@ -308,7 +308,7 @@ docker exec code-together-db pg_dump -U codetogether code_together > backup_$(da
 创建 `backup.sh`：
 ```bash
 #!/bin/bash
-# Code Together 数据库备份脚本
+# AI Together 数据库备份脚本
 
 BACKUP_DIR="./backups"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Code Together
+# AI Together
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shtdu/ai-together)](https://goreportcard.com/report/github.com/shtdu/ai-together)
@@ -15,7 +15,7 @@ A provider proxy platform for centralized management of AI coding tools (Claude 
 
 ## System Architecture
 
-Code Together consists of four main components:
+AI Together consists of four main components:
 
 - **Member Client** (`member/`) - Desktop client running a local HTTP proxy service
 - **Server** (`server/`) - Backend API service providing centralized management and collaboration features

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,4 +1,4 @@
-# Code Together
+# AI Together
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shtdu/ai-together)](https://goreportcard.com/report/github.com/shtdu/ai-together)
@@ -15,7 +15,7 @@
 
 ## 系统架构
 
-Code Together 由四个主要组件组成：
+AI Together 由四个主要组件组成：
 
 - **Member Client** (`member/`) - 桌面客户端，运行本地 HTTP 代理服务
 - **Server** (`server/`) - 后端 API 服务，提供集中管理和协作功能

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Currently, only the latest version of Code Together is supported with security updates.
+Currently, only the latest version of AI Together is supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -10,7 +10,7 @@ Currently, only the latest version of Code Together is supported with security u
 
 ## Reporting a Vulnerability
 
-We take the security of Code Together seriously. If you discover a security vulnerability, please report it responsibly.
+We take the security of AI Together seriously. If you discover a security vulnerability, please report it responsibly.
 
 ### How to Report
 
@@ -35,9 +35,9 @@ When reporting a vulnerability, please include:
 
 ### Security Best Practices
 
-If you're using Code Together, we recommend following these security best practices:
+If you're using AI Together, we recommend following these security best practices:
 
-* **Keep Updated**: Always use the latest version of Code Together
+* **Keep Updated**: Always use the latest version of AI Together
 * **Strong Credentials**: Use strong, unique passwords for all accounts
 * **JWT Secret**: Change the default `JWT_SECRET` in production environments
 * **Database Credentials**: Use strong database passwords and limit database access
@@ -48,7 +48,7 @@ If you're using Code Together, we recommend following these security best practi
 
 ### Security Features
 
-Code Together includes several security features:
+AI Together includes several security features:
 
 * **JWT Authentication**: Token-based authentication for API access
 * **Role-Based Access Control (RBAC)**: Fine-grained permissions using Casbin
@@ -76,11 +76,11 @@ cd manager && pnpm update
 
 ## License
 
-Code Together is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
+AI Together is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
 
 ## Privacy
 
-Code Together is designed with privacy in mind. We do not store user prompts or AI responses. Only usage metadata is collected for analytics purposes. For more information, see our [Privacy Policy](docs/privacy.md) (if available).
+AI Together is designed with privacy in mind. We do not store user prompts or AI responses. Only usage metadata is collected for analytics purposes. For more information, see our [Privacy Policy](docs/privacy.md) (if available).
 
 ## Contact
 

--- a/TEST.md
+++ b/TEST.md
@@ -1,6 +1,6 @@
 # Testing Guide
 
-Quick guide for running tests in the Code Together codebase.
+Quick guide for running tests in the AI Together codebase.
 
 ## Overview
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -3,7 +3,7 @@
 **Last Updated:** February 2025
 **Epic:** Epic 0 - Core Platform Foundation
 
-This document describes the architecture of the Code Together project from a system design perspective, covering design principles, technology choices, deployment patterns, and operational considerations.
+This document describes the architecture of the AI Together project from a system design perspective, covering design principles, technology choices, deployment patterns, and operational considerations.
 
 ## Table of Contents
 
@@ -119,7 +119,7 @@ AI Tool → Proxy (extracts metadata only) → Server (stores metadata)
 
 ## System Overview
 
-Code Together is a **distributed multi-tenant SaaS platform** for AI provider management with the following characteristics:
+AI Together is a **distributed multi-tenant SaaS platform** for AI provider management with the following characteristics:
 
 - **Three-tier architecture:** Client → Application → Data
 - **Multi-protocol support:** Claude, Codex, OpenCode with extensible provider model
@@ -129,7 +129,7 @@ Code Together is a **distributed multi-tenant SaaS platform** for AI provider ma
 
 ## Overview
 
-Code Together is a three-tier distributed system:
+AI Together is a three-tier distributed system:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐

--- a/docs/design/constitution.md
+++ b/docs/design/constitution.md
@@ -1,4 +1,4 @@
-# Code Together Design Constitution
+# AI Together Design Constitution
 
 **Version:** 1.0
 **Last Updated:** February 2025
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-This document captures the fundamental design principles that govern the Code Together project. All technical decisions SHOULD align with these principles unless explicitly justified.
+This document captures the fundamental design principles that govern the AI Together project. All technical decisions SHOULD align with these principles unless explicitly justified.
 
 ---
 

--- a/docs/ears/00_overview/README.md
+++ b/docs/ears/00_overview/README.md
@@ -1,6 +1,6 @@
 # Product Overview
 
-Code Together is a **team collaboration platform for AI development tools**. It helps teams manage AI service providers, track usage, and control costs across their organization.
+AI Together is a **team collaboration platform for AI development tools**. It helps teams manage AI service providers, track usage, and control costs across their organization.
 
 ## Purpose
 
@@ -10,7 +10,7 @@ AI development tools (Claude Code, Codex, OpenCode) require API keys and provide
 - Switching providers requires updating every developer's setup
 - Costs are opaque until bills arrive
 
-Code Together solves these problems by:
+AI Together solves these problems by:
 - **Centralized configuration** - Managers set up providers once, everyone gets them automatically
 - **Transparent routing** - Developers use their normal tools, requests route through configured providers
 - **Automatic failover** - If a provider fails, automatically switch to backup providers

--- a/docs/ears/01_identity_and_access/01_user_accounts/README.md
+++ b/docs/ears/01_identity_and_access/01_user_accounts/README.md
@@ -1,6 +1,6 @@
 # User Accounts
 
-Users create accounts to access Code Together. Accounts can be standalone (single-user) or connected to a team server.
+Users create accounts to access AI Together. Accounts can be standalone (single-user) or connected to a team server.
 
 ## Purpose
 
@@ -16,7 +16,7 @@ Allow users to securely access the system with appropriate permissions based on 
 
 ### 1. Account Creation
 
-**User Story:** As a new organization creator, I want to create my organization so my team can start using Code Together.
+**User Story:** As a new organization creator, I want to create my organization so my team can start using AI Together.
 
 #### Ubiquitous Requirements (Password Rules)
 

--- a/docs/ears/01_identity_and_access/02_roles_permissions/README.md
+++ b/docs/ears/01_identity_and_access/02_roles_permissions/README.md
@@ -1,6 +1,6 @@
 # Roles & Permissions
 
-Code Together has two user roles with different permissions. This ensures users can access appropriate features based on their responsibilities.
+AI Together has two user roles with different permissions. This ensures users can access appropriate features based on their responsibilities.
 
 ## Purpose
 

--- a/docs/ears/01_identity_and_access/03_multi_tenancy/README.md
+++ b/docs/ears/01_identity_and_access/03_multi_tenancy/README.md
@@ -1,6 +1,6 @@
 # Multi-Tenancy
 
-Each Code Together customer (organization) is a separate tenant with completely isolated data. Users from one organization never see or interact with data from another organization.
+Each AI Together customer (organization) is a separate tenant with completely isolated data. Users from one organization never see or interact with data from another organization.
 
 ## Purpose
 

--- a/docs/ears/01_identity_and_access/04_licensing/README.md
+++ b/docs/ears/01_identity_and_access/04_licensing/README.md
@@ -1,6 +1,6 @@
 # Licensing
 
-Code Together uses a 2-type license system: Open Source (free) and Commercial (paid). The system gracefully degrades when no license is active.
+AI Together uses a 2-type license system: Open Source (free) and Commercial (paid). The system gracefully degrades when no license is active.
 
 ## Purpose
 

--- a/docs/ears/01_identity_and_access/README.md
+++ b/docs/ears/01_identity_and_access/README.md
@@ -14,7 +14,7 @@ Enable secure access control, user management, and feature differentiation based
 
 ## Overview
 
-Code Together supports two types of users with different permissions. Organizations (tenants) are completely isolated from each other. License types determine which features are available.
+AI Together supports two types of users with different permissions. Organizations (tenants) are completely isolated from each other. License types determine which features are available.
 
 ## Subdomains
 

--- a/docs/ears/05_user_interfaces/03_accessibility/README.md
+++ b/docs/ears/05_user_interfaces/03_accessibility/README.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-Ensure Code Together is usable by people with disabilities, following WCAG guidelines and platform-specific accessibility standards.
+Ensure AI Together is usable by people with disabilities, following WCAG guidelines and platform-specific accessibility standards.
 
 ## Current Implementation
 

--- a/docs/ears/05_user_interfaces/README.md
+++ b/docs/ears/05_user_interfaces/README.md
@@ -1,6 +1,6 @@
 # User Interfaces
 
-Code Together provides two interfaces for different user types and use cases.
+AI Together provides two interfaces for different user types and use cases.
 
 ## Purpose
 

--- a/docs/ears/06_system_behaviors/01_privacy/README.md
+++ b/docs/ears/06_system_behaviors/01_privacy/README.md
@@ -1,6 +1,6 @@
 # Privacy
 
-Code Together is designed to be privacy-first. We never access or store prompt or response content from AI tools.
+AI Together is designed to be privacy-first. We never access or store prompt or response content from AI tools.
 
 ## Purpose
 

--- a/docs/ears/06_system_behaviors/02_security/README.md
+++ b/docs/ears/06_system_behaviors/02_security/README.md
@@ -1,6 +1,6 @@
 # Security
 
-Code Together implements multiple layers of security to protect user data and system access.
+AI Together implements multiple layers of security to protect user data and system access.
 
 ## Purpose
 

--- a/docs/ears/06_system_behaviors/03_performance/README.md
+++ b/docs/ears/06_system_behaviors/03_performance/README.md
@@ -1,6 +1,6 @@
 # Performance
 
-Code Together is designed for high performance with minimal overhead on AI tool requests.
+AI Together is designed for high performance with minimal overhead on AI tool requests.
 
 ## Purpose
 

--- a/docs/ears/06_system_behaviors/04_compliance/README.md
+++ b/docs/ears/06_system_behaviors/04_compliance/README.md
@@ -1,6 +1,6 @@
 # Compliance
 
-Code Together is designed to comply with major data protection regulations and industry standards.
+AI Together is designed to comply with major data protection regulations and industry standards.
 
 ## Purpose
 

--- a/docs/spec/00_overview/README.md
+++ b/docs/spec/00_overview/README.md
@@ -1,6 +1,6 @@
 # Product Overview
 
-Code Together is a **team collaboration platform for AI development tools**. It helps teams manage AI service providers, track usage, and control costs across their organization.
+AI Together is a **team collaboration platform for AI development tools**. It helps teams manage AI service providers, track usage, and control costs across their organization.
 
 ## Purpose
 
@@ -10,7 +10,7 @@ AI development tools (Claude Code, Codex, OpenCode) require API keys and provide
 - Switching providers requires updating every developer's setup
 - Costs are opaque until bills arrive
 
-Code Together solves these problems by:
+AI Together solves these problems by:
 - **Centralized configuration** - Managers set up providers once, everyone gets them automatically
 - **Transparent routing** - Developers use their normal tools, requests route through configured providers
 - **Automatic failover** - If a provider fails, automatically switch to backup providers
@@ -119,7 +119,7 @@ System behaviors that protect users and organizations:
 ### Member Experience
 
 ```
-1. Install Code Together desktop app
+1. Install AI Together desktop app
 2. Login to team account (or use standalone)
 3. Desktop app auto-configures AI tools
 4. Use AI tools normally - requests route through configured providers

--- a/docs/spec/01_identity_and_access/01_user_accounts/README.md
+++ b/docs/spec/01_identity_and_access/01_user_accounts/README.md
@@ -1,6 +1,6 @@
 # User Accounts
 
-Users create accounts to access Code Together. Accounts can be standalone (single-user) or connected to a team server.
+Users create accounts to access AI Together. Accounts can be standalone (single-user) or connected to a team server.
 
 ## Purpose
 
@@ -14,7 +14,7 @@ Allow users to securely access the system with appropriate permissions based on 
 
 ## User Stories
 
-- As an **organization creator**, I want to create my organization so my team can start using Code Together
+- As an **organization creator**, I want to create my organization so my team can start using AI Together
 - As a **manager**, I want to invite team members so they can access our team configuration
 - As a **manager**, I want to deactivate users who leave our organization
 - As a **user**, I want to stay logged in so I don't have to re-enter my password constantly
@@ -24,7 +24,7 @@ Allow users to securely access the system with appropriate permissions based on 
 
 ### Organization Creation
 
-**User Story:** As a new organization creator, I want to create my organization so my team can start using Code Together.
+**User Story:** As a new organization creator, I want to create my organization so my team can start using AI Together.
 
 **Workflow:**
 1. User navigates to registration page

--- a/docs/spec/01_identity_and_access/02_roles_permissions/README.md
+++ b/docs/spec/01_identity_and_access/02_roles_permissions/README.md
@@ -1,6 +1,6 @@
 # Roles & Permissions
 
-Code Together has two user roles with different permissions. This ensures users can access appropriate features based on their responsibilities.
+AI Together has two user roles with different permissions. This ensures users can access appropriate features based on their responsibilities.
 
 ## Purpose
 

--- a/docs/spec/01_identity_and_access/03_multi_tenancy/README.md
+++ b/docs/spec/01_identity_and_access/03_multi_tenancy/README.md
@@ -1,6 +1,6 @@
 # Multi-Tenancy
 
-Each Code Together customer (organization) is a separate tenant with completely isolated data. Users from one organization never see or interact with data from another organization.
+Each AI Together customer (organization) is a separate tenant with completely isolated data. Users from one organization never see or interact with data from another organization.
 
 ## Purpose
 

--- a/docs/spec/01_identity_and_access/04_licensing/README.md
+++ b/docs/spec/01_identity_and_access/04_licensing/README.md
@@ -1,6 +1,6 @@
 # Licensing
 
-Code Together uses a 2-type license system: Open Source (free) and Commercial (paid). The system gracefully degrades when no license is active.
+AI Together uses a 2-type license system: Open Source (free) and Commercial (paid). The system gracefully degrades when no license is active.
 
 ## Purpose
 

--- a/docs/spec/01_identity_and_access/README.md
+++ b/docs/spec/01_identity_and_access/README.md
@@ -14,7 +14,7 @@ Enable secure access control, user management, and feature differentiation based
 
 ## Overview
 
-Code Together supports two types of users with different permissions. Organizations (tenants) are completely isolated from each other. License types determine which features are available.
+AI Together supports two types of users with different permissions. Organizations (tenants) are completely isolated from each other. License types determine which features are available.
 
 ## Subdomains
 

--- a/docs/spec/04_usage_insights/01_data_collection/README.md
+++ b/docs/spec/04_usage_insights/01_data_collection/README.md
@@ -48,7 +48,7 @@ Every AI tool request generates a record with:
 
 ```
 1. User's AI tool makes request
-2. Request passes through Code Together proxy
+2. Request passes through AI Together proxy
 3. Proxy extracts metadata (no content inspection)
 4. Response returns to user
 5. Proxy extracts token counts from response

--- a/docs/spec/05_user_interfaces/01_member_app/README.md
+++ b/docs/spec/05_user_interfaces/01_member_app/README.md
@@ -106,7 +106,7 @@ Give members a simple, unobtrusive way to use AI tools with team-configured prov
 
 ```
 ┌─────────────────────────────────────────┐
-│ Code Together    [Server] [Settings] [Log] │
+│ AI Together    [Server] [Settings] [Log] │
 ├─────────────────────────────────────────┤
 │ [Usage Heatmap - GitHub style]          │
 ├─────────────────────────────────────────┤
@@ -145,7 +145,7 @@ Give members a simple, unobtrusive way to use AI tools with team-configured prov
 
 ### System Tray Menu
 
-- Show Code Together
+- Show AI Together
 - Enable/disable Claude Code proxy
 - Enable/disable Codex proxy
 - Enable/disable OpenCode proxy
@@ -183,7 +183,7 @@ Give members a simple, unobtrusive way to use AI tools with team-configured prov
 
 1. Download `CodeTogether.dmg`
 2. Open disk image
-3. Drag Code Together to Applications
+3. Drag AI Together to Applications
 4. App installs to `/Applications`
 5. Launch from Launchpad or Applications
 

--- a/docs/spec/05_user_interfaces/02_manager_dashboard/README.md
+++ b/docs/spec/05_user_interfaces/02_manager_dashboard/README.md
@@ -127,7 +127,7 @@ Provide managers with a comprehensive interface for managing their team's AI too
 
 ```
 ┌─────────────────────────────────────────────┐
-│ ☰  Code Together        [Admin] [Logout]    │
+│ ☰  AI Together        [Admin] [Logout]    │
 ├─────────────────────────────────────────────┤
 │ Dashboard                                     │
 │ Users                                        │

--- a/docs/spec/05_user_interfaces/03_accessibility/README.md
+++ b/docs/spec/05_user_interfaces/03_accessibility/README.md
@@ -1,10 +1,10 @@
 # Accessibility
 
-Code Together interfaces are designed to be accessible to users with disabilities.
+AI Together interfaces are designed to be accessible to users with disabilities.
 
 ## Purpose
 
-Ensure all users can effectively use Code Together, regardless of ability.
+Ensure all users can effectively use AI Together, regardless of ability.
 
 ## Status
 
@@ -12,7 +12,7 @@ Ensure all users can effectively use Code Together, regardless of ability.
 
 ## Accessibility Standards
 
-Code Together aims to meet:
+AI Together aims to meet:
 - **WCAG 2.1 Level AA** - Web Content Accessibility Guidelines
 - **Section 508** - U.S. federal accessibility requirements
 

--- a/docs/spec/05_user_interfaces/README.md
+++ b/docs/spec/05_user_interfaces/README.md
@@ -1,6 +1,6 @@
 # User Interfaces
 
-Code Together provides two interfaces for different user types and use cases.
+AI Together provides two interfaces for different user types and use cases.
 
 ## Purpose
 

--- a/docs/spec/06_system_behaviors/01_privacy/README.md
+++ b/docs/spec/06_system_behaviors/01_privacy/README.md
@@ -1,6 +1,6 @@
 # Privacy
 
-Code Together is designed to be privacy-first. We never access or store prompt or response content from AI tools.
+AI Together is designed to be privacy-first. We never access or store prompt or response content from AI tools.
 
 ## Purpose
 

--- a/docs/spec/06_system_behaviors/02_security/README.md
+++ b/docs/spec/06_system_behaviors/02_security/README.md
@@ -1,6 +1,6 @@
 # Security
 
-Code Together implements multiple layers of security to protect user data and system access.
+AI Together implements multiple layers of security to protect user data and system access.
 
 ## Purpose
 

--- a/docs/spec/06_system_behaviors/03_performance/README.md
+++ b/docs/spec/06_system_behaviors/03_performance/README.md
@@ -1,6 +1,6 @@
 # Performance
 
-Code Together is designed for minimal performance impact on AI tool usage.
+AI Together is designed for minimal performance impact on AI tool usage.
 
 ## Purpose
 

--- a/docs/spec/06_system_behaviors/04_compliance/README.md
+++ b/docs/spec/06_system_behaviors/04_compliance/README.md
@@ -1,6 +1,6 @@
 # Compliance
 
-Code Together is designed to comply with relevant data protection and security regulations.
+AI Together is designed to comply with relevant data protection and security regulations.
 
 ## Purpose
 

--- a/docs/spec/CLAUDE.md
+++ b/docs/spec/CLAUDE.md
@@ -1,6 +1,6 @@
 # spec — MECE Product Documentation
 
-This directory contains **product-focused documentation** for Code Together, structured using the **MECE** methodology: **M**utually **E**xclusive and **C**ollectively **E**xhaustive.
+This directory contains **product-focused documentation** for AI Together, structured using the **MECE** methodology: **M**utually **E**xclusive and **C**ollectively **E**xhaustive.
 
 ## Purpose
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,6 +1,6 @@
-# Code Together Product Documentation
+# AI Together Product Documentation
 
-This directory contains **product-focused documentation** for Code Together, organized using the **MECE** methodology: **M**utually **E**xclusive and **C**ollectively **E**xhaustive.
+This directory contains **product-focused documentation** for AI Together, organized using the **MECE** methodology: **M**utually **E**xclusive and **C**ollectively **E**xhaustive.
 
 ## Quick Navigation
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-This module contains black-box integration tests for the Code Together server API.
+This module contains black-box integration tests for the AI Together server API.
 
 ## Prerequisites
 

--- a/integration/analytics_aggregation_test.go
+++ b/integration/analytics_aggregation_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/analytics_e2e_test.go
+++ b/integration/analytics_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/analytics_edge_cases_test.go
+++ b/integration/analytics_edge_cases_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/analytics_filter_test.go
+++ b/integration/analytics_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/analytics_time_test.go
+++ b/integration/analytics_time_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/cleanup.go
+++ b/integration/cleanup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/fixtures.go
+++ b/integration/fixtures.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/integration.design.md
+++ b/integration/integration.design.md
@@ -2,7 +2,7 @@
 
 > **Current Status: 171/171 tests passing (100%)** ✅
 >
-> Complete integration test suite for the Code Together server API.
+> Complete integration test suite for the AI Together server API.
 > **3 tests skipped due to server-side issues.**
 
 ## Quick Links

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/license_test.go
+++ b/integration/license_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/mgr_dashboard_test.go
+++ b/integration/mgr_dashboard_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/mgr_team_test.go
+++ b/integration/mgr_team_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/mgr_users_crud_test.go
+++ b/integration/mgr_users_crud_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/permission_test.go
+++ b/integration/permission_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/provider_test.go
+++ b/integration/provider_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/usage_test.go
+++ b/integration/usage_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/integration/user_test.go
+++ b/integration/user_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/manager/CLAUDE.md
+++ b/manager/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-The Manager client is the administrative web interface for the Code Together platform. It provides team-level dashboards, usage analytics, user management, and token usage tracking for AI coding tools (Claude Code, Codex, and OpenCode).
+The Manager client is the administrative web interface for the AI Together platform. It provides team-level dashboards, usage analytics, user management, and token usage tracking for AI coding tools (Claude Code, Codex, and OpenCode).
 
 This is a **React 18 + TypeScript** single-page application (SPA) built with:
 - **Vite** for build tooling and dev server

--- a/manager/README.docker.md
+++ b/manager/README.docker.md
@@ -1,6 +1,6 @@
 # Manager Docker Deployment
 
-The Code Together Manager UI is packaged as a Docker container with nginx serving the React SPA and acting as a reverse proxy to the backend server.
+The AI Together Manager UI is packaged as a Docker container with nginx serving the React SPA and acting as a reverse proxy to the backend server.
 
 ## Quick Start
 

--- a/manager/src/components/layout/Header.tsx
+++ b/manager/src/components/layout/Header.tsx
@@ -66,7 +66,7 @@ export default function Header({ onMenuClick }: HeaderProps) {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mr: 3 }}>
           <CodeIcon />
           <Typography variant="h6" noWrap fontWeight="bold">
-            Code Together
+            AI Together
           </Typography>
         </Box>
 

--- a/manager/src/pages/LoginPage.tsx
+++ b/manager/src/pages/LoginPage.tsx
@@ -53,7 +53,7 @@ export default function LoginPage() {
       <Card sx={{ maxWidth: 400, width: '100%' }}>
         <CardContent sx={{ p: 4 }}>
           <Typography variant="h4" component="h1" gutterBottom textAlign="center">
-            Code Together
+            AI Together
           </Typography>
           <Typography
             variant="body2"

--- a/manager/src/pages/SetupPage.tsx
+++ b/manager/src/pages/SetupPage.tsx
@@ -166,7 +166,7 @@ export default function SetupPage() {
       <Card sx={{ maxWidth: 600, width: '100%' }}>
         <CardContent sx={{ p: 4 }}>
           <Typography variant="h4" component="h1" gutterBottom textAlign="center">
-            Welcome to Code Together
+            Welcome to AI Together
           </Typography>
           <Typography
             variant="body2"

--- a/member/build/config.yml
+++ b/member/build/config.yml
@@ -4,12 +4,12 @@
 version: '3'
 # This information is used to generate the build assets.
 info:
-  companyName: "Code Together" # The name of the company
-  productName: "Code Together" # The name of the application
+  companyName: "AI Together" # The name of the company
+  productName: "AI Together" # The name of the application
   productIdentifier: "com.codeswitch.app" # The unique product identifier
   description: "Manage Claude & Codex & OpenCode relays, providers, and request logs." # The application description
-  copyright: "(c) 2025, Code Together" # Copyright text
-  comments: "Code Together desktop relay controller" # Comments
+  copyright: "(c) 2025, AI Together" # Copyright text
+  comments: "AI Together desktop relay controller" # Comments
   version: "0.4.0.1" # The application version
 # Dev mode configuration
 dev_mode:

--- a/member/build/linux/nfpm/nfpm.yaml
+++ b/member/build/linux/nfpm/nfpm.yaml
@@ -11,7 +11,7 @@ section: "default"
 priority: "extra"
 maintainer: ${GIT_COMMITTER_NAME} <${GIT_COMMITTER_EMAIL}>
 description: "Manage Claude & Codex relays, providers, and request logs."
-vendor: "Code Together"
+vendor: "AI Together"
 homepage: "https://wails.io"
 license: "MIT"
 release: "1"

--- a/member/build/windows/info.json
+++ b/member/build/windows/info.json
@@ -5,11 +5,11 @@
 	"info": {
 		"0000": {
 			"ProductVersion": "0.4.0.1",
-			"CompanyName": "Code Together",
+			"CompanyName": "AI Together",
 			"FileDescription": "Manage Claude & Codex relays, providers, and request logs.",
-			"LegalCopyright": "(c) 2025, Code Together",
-			"ProductName": "Code Together",
-			"Comments": "Code Together desktop relay controller"
+			"LegalCopyright": "(c) 2025, AI Together",
+			"ProductName": "AI Together",
+			"Comments": "AI Together desktop relay controller"
 		}
 	}
 }

--- a/member/cmd/cli/config.go
+++ b/member/cmd/cli/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/cmd/cli/main.go
+++ b/member/cmd/cli/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/cmd/cli/main_test.go
+++ b/member/cmd/cli/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/cmd/cli/providers.go
+++ b/member/cmd/cli/providers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/cmd/cli/providers_test.go
+++ b/member/cmd/cli/providers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/frontend/src/locales/en.json
+++ b/member/frontend/src/locales/en.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "title": "Code Together",
+    "title": "AI Together",
     "login": "Login"
   },
   "menus": {
@@ -41,7 +41,7 @@
     },
     "main": {
       "hero": {
-        "eyebrow": "Code Together Client",
+        "eyebrow": "AI Together Client",
         "title": "Team Collaboration AI Coding",
         "lead": "The green heatmap highlights daily compute and token usage so we can monitor each vendor's load."
       },

--- a/member/frontend/src/locales/zh.json
+++ b/member/frontend/src/locales/zh.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "title": "Code Together",
+    "title": "AI Together",
     "login": "登录"
   },
   "menus": {

--- a/member/internal/hookdb/db.go
+++ b/member/internal/hookdb/db.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/internal/models/request_log.go
+++ b/member/internal/models/request_log.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/main.go
+++ b/member/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -221,7 +221,7 @@ func main() {
 	// 'Bind' is a list of Go struct instances. The frontend has access to the methods of these instances.
 	// 'Mac' options tailor the application when running an macOS.
 	app := application.New(application.Options{
-		Name:        "Code Together",
+		Name:        "AI Together",
 		Description: "Claude Code and Codex provier manager",
 		Services:    servicesList,
 		Assets: application.AssetOptions{
@@ -232,10 +232,10 @@ func main() {
 		},
 	})
 
-	// Set minimal menu to show only app name (Code Together) on macOS
+	// Set minimal menu to show only app name (AI Together) on macOS
 	menu := application.NewMenu()
 	if runtime.GOOS == "darwin" {
-		menu.AddRole(application.AppMenu)  // Adds "Code Together" menu with About, Preferences, Quit
+		menu.AddRole(application.AppMenu)  // Adds "AI Together" menu with About, Preferences, Quit
 		menu.AddRole(application.EditMenu) // Adds Edit menu with Undo, Redo, Cut, Copy, Paste, Select All
 	}
 	app.Menu.Set(menu)
@@ -267,7 +267,7 @@ func main() {
 	// 'BackgroundColour' is the background colour of the window.
 	// 'URL' is the URL that will be loaded into the webview.
 	mainWindow := app.Window.NewWithOptions(application.WebviewWindowOptions{
-		Title:     "Code Together",
+		Title:     "AI Together",
 		Width:     1024,
 		Height:    800,
 		MinWidth:  600,
@@ -328,8 +328,8 @@ func main() {
 	})
 
 	systray := app.SystemTray.New()
-	// systray.SetLabel("Code Together")
-	systray.SetTooltip("Code Together")
+	// systray.SetLabel("AI Together")
+	systray.SetTooltip("AI Together")
 	if lightIcon := loadTrayIcon("assets/icon.png"); len(lightIcon) > 0 {
 		systray.SetIcon(lightIcon)
 	}

--- a/member/main_test.go
+++ b/member/main_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/requestlog_mock_test.go
+++ b/member/requestlog_mock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/resources/model-pricing/price.go
+++ b/member/resources/model-pricing/price.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/appsettings.go
+++ b/member/services/appsettings.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/authservice.go
+++ b/member/services/authservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/autostartservice.go
+++ b/member/services/autostartservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/backgroundsyncservice.go
+++ b/member/services/backgroundsyncservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/claudesettings.go
+++ b/member/services/claudesettings.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ func (css *ClaudeSettingsService) EnableProxy() error {
 		}
 	}
 
-	// Merge Code Together hooks into settings
+	// Merge AI Together hooks into settings
 	settings = mergeCTHooks(settings)
 
 	// Get or create env map
@@ -182,7 +182,7 @@ func getEnvString(env map[string]any, key string) string {
 // Using map[string]any to preserve all fields (permissions, hooks, statusLine, enabledPlugins, etc.)
 type claudeSettingsFile map[string]any
 
-// getCTHookConfig returns the Code Together hook configuration template
+// getCTHookConfig returns the AI Together hook configuration template
 // The hook command sends event data to the local proxy for collection
 func getCTHookConfig() map[string]any {
 	return map[string]any{
@@ -254,7 +254,7 @@ func shouldAddHook(settings map[string]any, hookType string) bool {
 	return true
 }
 
-// mergeCTHooks merges Code Together hooks into existing settings
+// mergeCTHooks merges AI Together hooks into existing settings
 // Preserves all existing user hooks, only adds hooks that don't already exist
 func mergeCTHooks(settings map[string]any) map[string]any {
 	// Create a copy to avoid modifying the original
@@ -270,7 +270,7 @@ func mergeCTHooks(settings map[string]any) map[string]any {
 
 	hooks := result["hooks"].(map[string]any)
 
-	// Hook event types that Code Together collects
+	// Hook event types that AI Together collects
 	hookEvents := []string{
 		"Notification",
 		"PermissionRequest",

--- a/member/services/claudesettings_test.go
+++ b/member/services/claudesettings_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/codexsettings.go
+++ b/member/services/codexsettings.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/collect_test.go
+++ b/member/services/collect_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/collectorutil.go
+++ b/member/services/collectorutil.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/collectorutil_test.go
+++ b/member/services/collectorutil_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/config.go
+++ b/member/services/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/configservice.go
+++ b/member/services/configservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/configservice_test.go
+++ b/member/services/configservice_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/configsyncservice.go
+++ b/member/services/configsyncservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/hookservice.go
+++ b/member/services/hookservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/hookservice_test.go
+++ b/member/services/hookservice_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/importservice.go
+++ b/member/services/importservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/logservice.go
+++ b/member/services/logservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/mcpservice.go
+++ b/member/services/mcpservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/opencodesettings.go
+++ b/member/services/opencodesettings.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ const (
 	opencodeAuthTokenValue   = "code-together"
 	opencodeSchemaURL        = "https://opencode.ai/config.json"
 	codetogetherProviderID   = "codetogether"
-	codetogetherProviderName = "Code Together"
+	codetogetherProviderName = "AI Together"
 	codetogetherProviderNpm  = "@ai-sdk/openai-compatible"
 )
 
@@ -309,7 +309,7 @@ func ensureProviderStructure(settings opencodeSettingsFile) {
 	}
 }
 
-// getCodeTogetherProvider retrieves the Code Together provider configuration
+// getCodeTogetherProvider retrieves the AI Together provider configuration
 // Returns the provider config map, or nil if not found
 func getCodeTogetherProvider(settings opencodeSettingsFile) (map[string]interface{}, error) {
 	if settings == nil {
@@ -329,7 +329,7 @@ func getCodeTogetherProvider(settings opencodeSettingsFile) (map[string]interfac
 	return ctProvider, nil
 }
 
-// setCodeTogetherProvider sets or updates the Code Together provider configuration
+// setCodeTogetherProvider sets or updates the AI Together provider configuration
 // Always uses "default" as the model ID - the relay service handles model mapping
 func setCodeTogetherProvider(settings opencodeSettingsFile, baseURL string, providers []Provider) {
 	ensureProviderStructure(settings)
@@ -345,7 +345,7 @@ func setCodeTogetherProvider(settings opencodeSettingsFile, baseURL string, prov
 	// Set the top-level model field
 	settings["model"] = modelID
 
-	// Create the Code Together provider config
+	// Create the AI Together provider config
 	ctProvider := map[string]interface{}{
 		"npm":  codetogetherProviderNpm,
 		"name": codetogetherProviderName,

--- a/member/services/opencodesettings_test.go
+++ b/member/services/opencodesettings_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ func TestGetCodeTogetherProvider(t *testing.T) {
 				"provider": map[string]interface{}{
 					"codetogether": map[string]interface{}{
 						"npm":  "@ai-sdk/openai-compatible",
-						"name": "Code Together",
+						"name": "AI Together",
 					},
 				},
 			},

--- a/member/services/permissionservice.go
+++ b/member/services/permissionservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/providerrelay.go
+++ b/member/services/providerrelay.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/providerrelay_test.go
+++ b/member/services/providerrelay_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/providerservice.go
+++ b/member/services/providerservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/providerservice_test.go
+++ b/member/services/providerservice_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/reportservice.go
+++ b/member/services/reportservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/serverconfigservice.go
+++ b/member/services/serverconfigservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/servicestore.go
+++ b/member/services/servicestore.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/skillservice.go
+++ b/member/services/skillservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/usagesyncservice.go
+++ b/member/services/usagesyncservice.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/services/usagesyncservice_test.go
+++ b/member/services/usagesyncservice_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/member/version_service.go
+++ b/member/version_service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -1,10 +1,10 @@
 # CLAUDE.md - Server
 
-This file provides guidance for working with the Code Together server (backend API).
+This file provides guidance for working with the AI Together server (backend API).
 
 ## Module Overview
 
-The server is a Go backend that provides centralized management, authentication, and usage tracking for the Code Together platform. It handles team management, provider configuration, and aggregates usage data from member clients.
+The server is a Go backend that provides centralized management, authentication, and usage tracking for the AI Together platform. It handles team management, provider configuration, and aggregates usage data from member clients.
 
 **Module name:** `switch-server`
 **Module path:** `server/`

--- a/server/LICENSE_SYSTEM.md
+++ b/server/LICENSE_SYSTEM.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Code Together license system controls access to features based on configurable limits for user seats and AI provider configurations. The system uses Ed25519 cryptographic signing to ensure license integrity and supports multiple license tiers with increasing capabilities.
+The AI Together license system controls access to features based on configurable limits for user seats and AI provider configurations. The system uses Ed25519 cryptographic signing to ensure license integrity and supports multiple license tiers with increasing capabilities.
 
 ### Key Concepts
 

--- a/server/README.docker.md
+++ b/server/README.docker.md
@@ -1,6 +1,6 @@
 # Server Docker Deployment
 
-The Code Together server can be easily deployed using Docker.
+The AI Together server can be easily deployed using Docker.
 
 ## Quick Start
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-# Code Together Server
+# AI Together Server
 
 ## Air (Live Reload)
 
@@ -68,7 +68,7 @@ The server implements role-based permissions using Casbin:
 
 ### License System
 
-The Code Together server includes a license management system that controls user seat limits and AI provider configuration limits based on license tier. When no valid license is active, the system defaults to Tier 0.0 (Community) with basic limits.
+The AI Together server includes a license management system that controls user seat limits and AI provider configuration limits based on license tier. When no valid license is active, the system defaults to Tier 0.0 (Community) with basic limits.
 
 #### License Impact
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/coverage_test.go
+++ b/server/coverage_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/analytics_handler.go
+++ b/server/handlers/analytics_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/analytics_handler_test.go
+++ b/server/handlers/analytics_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/auth_handler.go
+++ b/server/handlers/auth_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/auth_handler_mock_test.go
+++ b/server/handlers/auth_handler_mock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/auth_handler_simple_test.go
+++ b/server/handlers/auth_handler_simple_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/dashboard_handler.go
+++ b/server/handlers/dashboard_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/dashboard_handler_test.go
+++ b/server/handlers/dashboard_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/health_handler.go
+++ b/server/handlers/health_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/health_handler_test.go
+++ b/server/handlers/health_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/license_handler.go
+++ b/server/handlers/license_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/license_handler_mock_test.go
+++ b/server/handlers/license_handler_mock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/provider_handler.go
+++ b/server/handlers/provider_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/provider_handler_test.go
+++ b/server/handlers/provider_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/relay_handler.go
+++ b/server/handlers/relay_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/relay_handler_test.go
+++ b/server/handlers/relay_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/setup_handler.go
+++ b/server/handlers/setup_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/setup_handler_test.go
+++ b/server/handlers/setup_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/team_handler.go
+++ b/server/handlers/team_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/team_handler_test.go
+++ b/server/handlers/team_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/test_helpers.go
+++ b/server/handlers/test_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/usage_handler.go
+++ b/server/handlers/usage_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/usage_handler_test.go
+++ b/server/handlers/usage_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/user_handler.go
+++ b/server/handlers/user_handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handlers/user_handler_test.go
+++ b/server/handlers/user_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/middleware/auth_middleware.go
+++ b/server/middleware/auth_middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/middleware/auth_middleware_test.go
+++ b/server/middleware/auth_middleware_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/middleware/error_middleware.go
+++ b/server/middleware/error_middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/middleware/error_middleware_test.go
+++ b/server/middleware/error_middleware_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/middleware/license_middleware.go
+++ b/server/middleware/license_middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/middleware/license_middleware_test.go
+++ b/server/middleware/license_middleware_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/middleware/rbac.go
+++ b/server/middleware/rbac.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/middleware/rbac_test.go
+++ b/server/middleware/rbac_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/models/license.go
+++ b/server/models/license.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/models/license_test.go
+++ b/server/models/license_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/models/models_test.go
+++ b/server/models/models_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/interfaces.go
+++ b/server/repository/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/license_repository.go
+++ b/server/repository/license_repository.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/license_repository_interface.go
+++ b/server/repository/license_repository_interface.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/license_repository_test.go
+++ b/server/repository/license_repository_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/provider_repository.go
+++ b/server/repository/provider_repository.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/provider_repository_test.go
+++ b/server/repository/provider_repository_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/team_repository.go
+++ b/server/repository/team_repository.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/team_repository_test.go
+++ b/server/repository/team_repository_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/usage_repository.go
+++ b/server/repository/usage_repository.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/usage_repository_test.go
+++ b/server/repository/usage_repository_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/user_repository.go
+++ b/server/repository/user_repository.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/repository/user_repository_test.go
+++ b/server/repository/user_repository_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/scripts/generate_password.go
+++ b/server/scripts/generate_password.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/scripts/keygen/main.go
+++ b/server/scripts/keygen/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/interfaces.go
+++ b/server/services/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/license_service.go
+++ b/server/services/license_service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/license_service_test.go
+++ b/server/services/license_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/provider_service.go
+++ b/server/services/provider_service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/provider_service_test.go
+++ b/server/services/provider_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/service_mocks_test.go
+++ b/server/services/service_mocks_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/team_service.go
+++ b/server/services/team_service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/team_service_test.go
+++ b/server/services/team_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/usage_service.go
+++ b/server/services/usage_service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/usage_service_test.go
+++ b/server/services/usage_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/user_service.go
+++ b/server/services/user_service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/services/user_service_test.go
+++ b/server/services/user_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/testutil/fixtures.go
+++ b/server/testutil/fixtures.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/testutil/test_helpers.go
+++ b/server/testutil/test_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/version.go
+++ b/server/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/events/PostToolUse.go
+++ b/shared/events/PostToolUse.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/events/PreCompact.go
+++ b/shared/events/PreCompact.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/events/PreToolUse.go
+++ b/shared/events/PreToolUse.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/events/SessionEnd.go
+++ b/shared/events/SessionEnd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/events/Stop.go
+++ b/shared/events/Stop.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/events/SubagentStop.go
+++ b/shared/events/SubagentStop.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/events/UserPromptSubmit.go
+++ b/shared/events/UserPromptSubmit.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/README.md
+++ b/shared/hook-common/README.md
@@ -245,4 +245,4 @@ Key API changes:
 
 ## License
 
-Part of the Code Together project.
+Part of the AI Together project.

--- a/shared/hook-common/config/path.go
+++ b/shared/hook-common/config/path.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/config/path_test.go
+++ b/shared/hook-common/config/path_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/concurrent_test.go
+++ b/shared/hook-common/storage/concurrent_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/constants.go
+++ b/shared/hook-common/storage/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/db.go
+++ b/shared/hook-common/storage/db.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/db_test.go
+++ b/shared/hook-common/storage/db_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/git_integration_test.go
+++ b/shared/hook-common/storage/git_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/git_merge.go
+++ b/shared/hook-common/storage/git_merge.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/git_merge_test.go
+++ b/shared/hook-common/storage/git_merge_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/read.go
+++ b/shared/hook-common/storage/read.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/schema.go
+++ b/shared/hook-common/storage/schema.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/sqlite.go
+++ b/shared/hook-common/storage/sqlite.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/summary.go
+++ b/shared/hook-common/storage/summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/summary_report.go
+++ b/shared/hook-common/storage/summary_report.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/summary_types.go
+++ b/shared/hook-common/storage/summary_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/types.go
+++ b/shared/hook-common/storage/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-common/storage/write.go
+++ b/shared/hook-common/storage/write.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-utils/cwd.go
+++ b/shared/hook-utils/cwd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-utils/cwd_test.go
+++ b/shared/hook-utils/cwd_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-utils/git.go
+++ b/shared/hook-utils/git.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-utils/git_bench_test.go
+++ b/shared/hook-utils/git_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/hook-utils/git_test.go
+++ b/shared/hook-utils/git_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/integration/client.go
+++ b/shared/integration/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-// Package integration provides a client factory for the Code Together server API.
+// Package integration provides a client factory for the AI Together server API.
 package integration
 
 import (

--- a/shared/integration/doc.go
+++ b/shared/integration/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-// Package integration provides a type-safe client for the Code Together member client API.
+// Package integration provides a type-safe client for the AI Together member client API.
 // It is generated from the OpenAPI specification at docs/client_api/server_api.yaml.
 //
 // This spec is optimized for member client integration and includes:

--- a/shared/integration/errors.go
+++ b/shared/integration/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/integration/errors_test.go
+++ b/shared/integration/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/integration/transport.go
+++ b/shared/integration/transport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/integration/transport_test.go
+++ b/shared/integration/transport_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/integration/transport_verbose_test.go
+++ b/shared/integration/transport_verbose_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/integration_manager/client.go
+++ b/shared/integration_manager/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-// Package integration_manager provides a client factory for the Code Together Manager API.
+// Package integration_manager provides a client factory for the AI Together Manager API.
 package integration_manager
 
 import (

--- a/shared/integration_manager/doc.go
+++ b/shared/integration_manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-// Package integration_manager provides a client for the Code Together Manager API.
+// Package integration_manager provides a client for the AI Together Manager API.
 // It is auto-generated from the OpenAPI specification at docs/client_api/server_api_manager.yaml.
 //
 //go:generate oapi-codegen -package integration_manager -generate types,client,spec ../../docs/client_api/server_api_manager.yaml > generated.go

--- a/shared/integration_manager/transport.go
+++ b/shared/integration_manager/transport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/provider/builder.go
+++ b/shared/provider/builder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/provider/builder_test.go
+++ b/shared/provider/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/provider/config.go
+++ b/shared/provider/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/provider/model_helpers.go
+++ b/shared/provider/model_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/provider/model_helpers_test.go
+++ b/shared/provider/model_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/streaming/client.go
+++ b/shared/streaming/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/streaming/client_test.go
+++ b/shared/streaming/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/streaming/token_parsers.go
+++ b/shared/streaming/token_parsers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/streaming/token_parsers_test.go
+++ b/shared/streaming/token_parsers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/README.md
+++ b/shared/tools/hook-browser/README.md
@@ -1,6 +1,6 @@
 # Hook Browser
 
-A terminal user interface (TUI) for browsing and searching through hook event data collected by the Code Together platform. Built with [tview](https://github.com/rivo/tview) featuring a modern purple-themed design.
+A terminal user interface (TUI) for browsing and searching through hook event data collected by the AI Together platform. Built with [tview](https://github.com/rivo/tview) featuring a modern purple-themed design.
 
 ## Features
 
@@ -325,4 +325,4 @@ When adding features:
 
 ## License
 
-Part of the Code Together project. See main repository LICENSE.
+Part of the AI Together project. See main repository LICENSE.

--- a/shared/tools/hook-browser/cmd_summary.go
+++ b/shared/tools/hook-browser/cmd_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/app.go
+++ b/shared/tools/hook-browser/internal/model/app.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/handlers.go
+++ b/shared/tools/hook-browser/internal/model/handlers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/layout.go
+++ b/shared/tools/hook-browser/internal/model/layout.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/notifications.go
+++ b/shared/tools/hook-browser/internal/model/notifications.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/search.go
+++ b/shared/tools/hook-browser/internal/model/search.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/styles.go
+++ b/shared/tools/hook-browser/internal/model/styles.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/tree.go
+++ b/shared/tools/hook-browser/internal/model/tree.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/tree_test.go
+++ b/shared/tools/hook-browser/internal/model/tree_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/internal/model/types.go
+++ b/shared/tools/hook-browser/internal/model/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-browser/main.go
+++ b/shared/tools/hook-browser/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/commands/clean.go
+++ b/shared/tools/hook-collector/commands/clean.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/commands/collect.go
+++ b/shared/tools/hook-collector/commands/collect.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/commands/export.go
+++ b/shared/tools/hook-collector/commands/export.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/internal/collector/collector.go
+++ b/shared/tools/hook-collector/internal/collector/collector.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/internal/collector/logger.go
+++ b/shared/tools/hook-collector/internal/collector/logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/internal/collector/logger_test.go
+++ b/shared/tools/hook-collector/internal/collector/logger_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/internal/config/config.go
+++ b/shared/tools/hook-collector/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/internal/config/config_test.go
+++ b/shared/tools/hook-collector/internal/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/internal/utils/disk.go
+++ b/shared/tools/hook-collector/internal/utils/disk.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-collector/main.go
+++ b/shared/tools/hook-collector/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-events-tool/main.go
+++ b/shared/tools/hook-events-tool/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-schema-analyzer/README.md
+++ b/shared/tools/hook-schema-analyzer/README.md
@@ -228,4 +228,4 @@ go build -o hook-schema-analyzer .
 
 ## License
 
-Part of the Code Together project.
+Part of the AI Together project.

--- a/shared/tools/hook-schema-analyzer/main.go
+++ b/shared/tools/hook-schema-analyzer/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/shared/tools/hook-schema-analyzer/validate.go
+++ b/shared/tools/hook-schema-analyzer/validate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Code Together
+// Copyright (c) 2025 AI Together
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Renamed all occurrences of 'Code Together' to 'AI Together' across 268 files
- Updated documentation, source code comments, configs, and localization files
- Excluded generated files (sqlc, etc.) to prevent conflicts on regeneration

## Test plan
- [x] Server tests pass (`go test ./...` in server/)
- [x] Go formatting verified (gofmt)
- [x] No remaining 'Code Together' references in tracked files

Closes #10