### PR TITLE
fix: resolve ESLint errors blocking CI

### DIFF
--- a/member/frontend/src/components/General/Index.vue
+++ b/member/frontend/src/components/General/Index.vue
@@ -6,7 +6,6 @@ import { Dialogs } from '@wailsio/runtime'
 import ListItem from '../Setting/ListRow.vue'
 import LanguageSwitcher from '../Setting/LanguageSwitcher.vue'
 import ThemeSetting from '../Setting/ThemeSetting.vue'
-import BaseModal from '../common/BaseModal.vue'
 import { fetchAppSettings, saveAppSettings, type AppSettings } from '../../services/appSettings'
 import {
   fetchConfigImportStatus,
@@ -18,7 +17,6 @@ import {
 } from '../../services/configImport'
 import { showToast } from '../../utils/toast'
 import BaseButton from '../common/BaseButton.vue'
-import BaseInput from '../common/BaseInput.vue'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -127,7 +125,7 @@ const canImportActive = computed(() =>
   hasCustomSelection.value ? canImportCustom.value : canImportDefault.value,
 )
 // TODO: Intended to hide it by Gene
-const showImportRow = computed(() => false && Boolean(importStatus.value) || hasCustomSelection.value)
+const showImportRow = computed(() => hasCustomSelection.value)
 const importPathLabel = computed(() => {
   if (!configPath.value) return ''
   return t('components.general.import.path', { path: configPath.value })

--- a/member/frontend/src/components/Logs/Index.vue
+++ b/member/frontend/src/components/Logs/Index.vue
@@ -556,10 +556,6 @@ const applyFilters = async () => {
   resetTimer()
 }
 
-const refreshLogs = () => {
-  void loadDashboard()
-}
-
 const manualRefresh = () => {
   resetTimer()
   void loadDashboard()
@@ -620,11 +616,6 @@ const durationColor = (value?: number) => {
   if (value < 2) return 'fast'
   if (value < 5) return 'medium'
   return 'slow'
-}
-
-const formatNumber = (value?: number) => {
-  if (value === undefined || value === null) return '—'
-  return value.toLocaleString()
 }
 
 const formatCurrency = (value?: number) => {

--- a/member/frontend/src/components/Main/Index.vue
+++ b/member/frontend/src/components/Main/Index.vue
@@ -211,8 +211,8 @@
               </div>
               <!-- <p class="card-subtitle">{{ card.apiUrl }}</p> -->
               <p
-                v-for="stats in [providerStatDisplay(card.name)]"
-                :key="`metrics-${card.id}`"
+                v-for="(stats, idx) in [providerStatDisplay(card.name)]"
+                :key="`metrics-${card.id}-${idx}`"
                 class="card-metrics"
               >
                 <template v-if="stats.state !== 'ready'">
@@ -426,7 +426,7 @@ import { fetchCurrentVersion } from '../../services/version'
 import { fetchAppSettings, type AppSettings } from '../../services/appSettings'
 import { getCurrentTheme, setTheme, type ThemeMode } from '../../utils/ThemeManager'
 import { useRouter } from 'vue-router'
-import { isAuthenticated, getCurrentUser, type User } from '../../services/auth'
+import { isAuthenticated, getCurrentUser } from '../../services/auth'
 import { canEditSettings } from '../../services/permission'
 import { showToast } from '../../utils/toast'
 
@@ -929,16 +929,6 @@ const providerStatDisplay = (providerName: string): ProviderStatDisplay => {
   }
 }
 
-const normalizeUrlWithScheme = (value: string) => {
-  if (!value) return ''
-  try {
-    const url = new URL(value)
-    return url.toString()
-  } catch {
-    return `https://${value}`
-  }
-}
-
 const startProviderStatsTimer = () => {
   stopProviderStatsTimer()
   providerStatsTimer = window.setInterval(() => {
@@ -1012,14 +1002,6 @@ const goToLogs = () => {
 
 const goToReports = () => {
   router.push('/reports')
-}
-
-const goToMcp = () => {
-  router.push('/mcp')
-}
-
-const goToSkill = () => {
-  router.push('/skill')
 }
 
 const goToServer = () => {

--- a/member/frontend/src/components/Mcp/index.vue
+++ b/member/frontend/src/components/Mcp/index.vue
@@ -422,7 +422,7 @@ const persistServers = async () => {
   }
 }
 
-const iconStyle = (name: string) => ({
+const iconStyle = (_name: string) => ({
   backgroundColor: 'rgba(255,255,255,0.08)',
   color: 'var(--text-primary)',
 })

--- a/member/frontend/src/components/Reports/Index.vue
+++ b/member/frontend/src/components/Reports/Index.vue
@@ -101,7 +101,7 @@ import KPICards from './KPICards.vue'
 import TimelineGantt from './TimelineGantt.vue'
 import InteractionSection from './InteractionSection.vue'
 import SessionTable from './SessionTable.vue'
-import { fetchDailyReport, getTodayDate, getPreviousDay, getNextDay, getMinDate, RETENTION_DAYS, type DailyReport, type ToolReport } from '../../services/reports'
+import { fetchDailyReport, getTodayDate, getPreviousDay, getNextDay, getMinDate, type DailyReport } from '../../services/reports'
 
 const router = useRouter()
 const { t } = useI18n()


### PR DESCRIPTION
## Summary
- Fix invalid v-for key in Main/Index.vue by using v-for index variable
- Fix constant truthiness expression in General/Index.vue showImportRow
- Remove unused imports (User, BaseModal, BaseInput, RETENTION_DAYS, ToolReport)
- Remove unused functions (normalizeUrlWithScheme, goToMcp, goToSkill, refreshLogs, formatNumber)
- Prefix intentionally unused parameter with underscore in Mcp/index.vue

## Test Plan
- [x] Run `make member-lint` - 0 errors, only warnings remain

Closes #41