### PR TITLE
test: remove stale RBAC TODOs from permission tests

### DIFF
--- a/integration/permission_test.go
+++ b/integration/permission_test.go
@@ -69,8 +69,6 @@ func (s *IntegrationTestSuite) TestPermissionAdminCanDeleteProvider() {
 }
 
 // TestPermissionMemberCanReadProviders tests that member can read providers.
-// TODO: SERVER FIX REQUIRED - RBAC not working for member read access
-// Server should allow members to read providers, but currently returns 403
 func (s *IntegrationTestSuite) TestPermissionMemberCanReadProviders() {
 	ctx := context.Background()
 
@@ -89,8 +87,6 @@ func (s *IntegrationTestSuite) TestPermissionMemberCanReadProviders() {
 }
 
 // TestPermissionMemberCannotCreateProvider tests that member cannot create providers.
-// TODO: SERVER FIX REQUIRED - RBAC not blocking member write operations
-// Server should return 403 when member tries to create provider
 func (s *IntegrationTestSuite) TestPermissionMemberCannotCreateProvider() {
 	ctx := context.Background()
 
@@ -114,9 +110,6 @@ func (s *IntegrationTestSuite) TestPermissionMemberCannotCreateProvider() {
 }
 
 // TestPermissionMemberCannotUpdateProvider tests that member cannot update providers.
-// TODO: Server RBAC not properly rejecting member write operations on providers
-// TODO: SERVER FIX REQUIRED - RBAC not blocking member write operations
-// Server should return 403 when member tries to update provider
 func (s *IntegrationTestSuite) TestPermissionMemberCannotUpdateProvider() {
 	ctx := context.Background()
 
@@ -143,8 +136,6 @@ func (s *IntegrationTestSuite) TestPermissionMemberCannotUpdateProvider() {
 }
 
 // TestPermissionMemberCannotDeleteProvider tests that member cannot delete providers.
-// TODO: SERVER FIX REQUIRED - RBAC not blocking member write operations
-// Server should return 403 when member tries to delete provider
 func (s *IntegrationTestSuite) TestPermissionMemberCannotDeleteProvider() {
 	ctx := context.Background()
 
@@ -178,8 +169,6 @@ func (s *IntegrationTestSuite) TestPermissionMemberCannotDeleteProvider() {
 }
 
 // TestPermissionMemberCannotAccessLicenseWrite tests that member cannot write to license.
-// TODO: SERVER FIX REQUIRED - RBAC not blocking member license write operations
-// Server should return 403 when member tries to activate license
 func (s *IntegrationTestSuite) TestPermissionMemberCannotAccessLicenseWrite() {
 	ctx := context.Background()
 
@@ -201,8 +190,6 @@ func (s *IntegrationTestSuite) TestPermissionMemberCannotAccessLicenseWrite() {
 }
 
 // TestPermissionMemberCanGetLicense tests that member can read license info.
-// TODO: SERVER FIX REQUIRED - RBAC not allowing member to read license
-// Server should allow members to read license information
 func (s *IntegrationTestSuite) TestPermissionMemberCanGetLicense() {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description

The TODO comments in `integration/permission_test.go` claiming "SERVER FIX REQUIRED - RBAC not working" were **stale**. The RBAC permission enforcement is fully functional - all 8 permission tests pass.

## Type of Change

- [ ] **Bug fix** - Non-breaking change that fixes an issue
- [ ] **New feature** - Non-breaking change that adds functionality
- [ ] **Breaking change** - Fix or feature that would cause existing functionality to not work as expected
- [ ] **Documentation** - Documentation only changes
- [ ] **Refactoring** - Code change that neither fixes a bug nor adds a feature
- [ ] **Performance** - Code change that improves performance
- [x] **Tests** - Adding or updating tests

## Related Issues

Closes #44

## Changes Made

- Removed misleading "SERVER FIX REQUIRED" TODO comments from `integration/permission_test.go`
- The comments were written before RBAC was fully implemented but are now obsolete

## CI Status

- [x] **Lint** - Code formatting and style checks
- [x] **Build** - All modules build successfully
- [x] **Test** - Unit tests pass

## Testing

- [ ] Unit tests pass locally (`make test`)
- [x] Integration tests pass locally (`make integration-test`)
- [ ] Manager lint passes locally (`cd manager && pnpm lint`)
- [x] Manual testing performed
- [ ] Added new tests for the changes
- [x] All existing tests still pass

### Test Cases

All 119 integration tests pass, including all 8 permission tests:

1. `TestPermissionMemberCanReadProviders` - Members can list providers ✅
2. `TestPermissionMemberCannotCreateProvider` - Members get 403 when creating ✅
3. `TestPermissionMemberCannotUpdateProvider` - Members get 403 when updating ✅
4. `TestPermissionMemberCannotDeleteProvider` - Members get 403 when deleting ✅
5. `TestPermissionMemberCannotAccessLicenseWrite` - Members get 403 when activating license ✅
6. `TestPermissionMemberCanGetLicense` - Members can read license info ✅
7. `TestPermissionAdminCanUpdateProvider` - Admins can update providers ✅
8. `TestPermissionAdminCanDeleteProvider` - Admins can delete providers ✅

## Documentation

- [x] Updated relevant documentation (removed misleading TODOs)

## Breaking Changes

None - this is only removing stale comments.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [x] My changes generate no new test failures

## Additional Notes

The RBAC implementation in `server/middleware/rbac.go` uses Casbin and is working correctly:
- **Member role**: read providers/config/license, sync config
- **Manager role**: full access to all resources