### PR TITLE
fix: correct release workflow paths for monorepo structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,39 +30,44 @@ jobs:
         run: go install github.com/wailsapp/wails/v3/cmd/wails3@latest
 
       - name: Install frontend dependencies
-        run: cd frontend && npm install
+        working-directory: ./member/frontend
+        run: npm install
 
       - name: Update build assets
+        working-directory: ./member
         run: wails3 task common:update:build-assets
 
       - name: Generate bindings
+        working-directory: ./member
         run: wails3 task common:generate:bindings
 
       - name: Build macOS ${{ matrix.arch }}
+        working-directory: ./member
         run: env ARCH=${{ matrix.arch }} wails3 task package
 
-      - name: Find app bundle
-        id: find-app
+      - name: Verify app bundle
+        working-directory: ./member
         run: |
-          if [ -d "bin/codeswitch.app" ]; then
-            echo "app_path=bin/codeswitch.app" >> $GITHUB_OUTPUT
-          elif [ -d "bin/CodeSwitch.app" ]; then
-            echo "app_path=bin/CodeSwitch.app" >> $GITHUB_OUTPUT
+          if [ -d "bin/CodeTogether.app" ]; then
+            echo "✓ App bundle found: bin/CodeTogether.app"
+            ls -lh bin/CodeTogether.app
           else
-            echo "App bundle not found" >&2
+            echo "✗ App bundle not found!"
+            echo "Listing bin directory:"
+            ls -la bin/
             exit 1
           fi
 
       - name: Archive macOS app
+        working-directory: ./member/bin
         run: |
-          cd bin
-          ditto -c -k --sequesterRsrc --keepParent "$(basename ${{ steps.find-app.outputs.app_path }})" codeswitch-macos-${{ matrix.arch }}.zip
+          ditto -c -k --sequesterRsrc --keepParent "CodeTogether.app" "codetogether-macos-${{ matrix.arch }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-${{ matrix.arch }}
-          path: bin/codeswitch-macos-${{ matrix.arch }}.zip
+          path: member/bin/codetogether-macos-${{ matrix.arch }}.zip
 
   build-windows:
     name: Build Windows
@@ -82,18 +87,22 @@ jobs:
         run: go install github.com/wailsapp/wails/v3/cmd/wails3@latest
 
       - name: Install frontend dependencies
-        run: cd frontend && npm install
+        working-directory: ./member/frontend
+        run: npm install
 
       - name: Install NSIS
         run: choco install nsis -y
 
       - name: Update build assets
+        working-directory: ./member
         run: wails3 task common:update:build-assets
 
       - name: Generate bindings
+        working-directory: ./member
         run: wails3 task common:generate:bindings
 
       - name: Build Windows Binary
+        working-directory: ./member
         run: |
           $env:ARCH = "amd64"
           wails3 task windows:build
@@ -101,10 +110,11 @@ jobs:
           PRODUCTION: "true"
 
       - name: Verify Binary
+        working-directory: ./member
         run: |
-          if (Test-Path "bin\CodeSwitch.exe") {
-            Write-Host "✓ Binary found: bin\CodeSwitch.exe"
-            Get-Item "bin\CodeSwitch.exe" | Format-List Name,Length,LastWriteTime
+          if (Test-Path "bin\CodeTogether.exe") {
+            Write-Host "✓ Binary found: bin\CodeTogether.exe"
+            Get-Item "bin\CodeTogether.exe" | Format-List Name,Length,LastWriteTime
           } else {
             Write-Host "✗ Binary not found!"
             Write-Host "Listing bin directory:"
@@ -113,11 +123,12 @@ jobs:
           }
 
       - name: Create NSIS Installer
+        working-directory: ./member
         run: |
           $env:PATH += ";C:\Program Files (x86)\NSIS"
           Push-Location build\windows\nsis
           wails3 generate webview2bootstrapper
-          $binaryPath = (Resolve-Path "..\..\..\bin\CodeSwitch.exe").Path
+          $binaryPath = (Resolve-Path "..\..\..\bin\CodeTogether.exe").Path
           Write-Host "Binary path: $binaryPath"
           makensis -DARG_WAILS_AMD64_BINARY="$binaryPath" project.nsi
           Pop-Location
@@ -127,8 +138,8 @@ jobs:
         with:
           name: windows-amd64
           path: |
-            bin/CodeSwitch-amd64-installer.exe
-            bin/CodeSwitch.exe
+            member/bin/CodeTogether-amd64-installer.exe
+            member/bin/CodeTogether.exe
 
   create-release:
     name: Create Release
@@ -148,10 +159,10 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p release-assets
-          cp artifacts/macos-arm64/codeswitch-macos-arm64.zip release-assets/
-          cp artifacts/macos-amd64/codeswitch-macos-amd64.zip release-assets/
-          cp artifacts/windows-amd64/CodeSwitch-amd64-installer.exe release-assets/
-          cp artifacts/windows-amd64/CodeSwitch.exe release-assets/
+          cp artifacts/macos-arm64/codetogether-macos-arm64.zip release-assets/
+          cp artifacts/macos-amd64/codetogether-macos-amd64.zip release-assets/
+          cp artifacts/windows-amd64/CodeTogether-amd64-installer.exe release-assets/
+          cp artifacts/windows-amd64/CodeTogether.exe release-assets/
           ls -lh release-assets/
 
       - name: Create Release
@@ -159,30 +170,21 @@ jobs:
         with:
           files: release-assets/*
           body: |
-            ## 新增功能
+            ## AI Together Release
 
-            ### 优先级分组调度
+            ## 安装说明 / Installation
 
-            新增 Level 字段（1-10）用于供应商优先级分组，实现更灵活的降级策略。
-
-            **主要改进**：
-            - 后端：重构调度逻辑为两层循环架构，优先尝试高优先级分组
-            - 前端：添加 Level 下拉选择器和可视化徽章（L1-L10）
-            - 国际化：支持中英文 Level 描述文本
-            - 测试：新增单元测试覆盖分组、排序和序列化逻辑
-
-            **使用场景**：
-            - 成本优化：低成本供应商优先，高成本作为备份
-            - 稳定性保障：高质量供应商优先，社区供应商降级
-            - 地域分组：国内供应商优先，国外供应商备份
-
-            **向后兼容**：未设置 Level 的供应商自动默认为 Level 1。
+            - **Windows**: Download `CodeTogether-amd64-installer.exe` to install, or `CodeTogether.exe` to run directly
+            - **macOS (Apple Silicon)**: Download `codetogether-macos-arm64.zip`
+            - **macOS (Intel)**: Download `codetogether-macos-amd64.zip`
 
             ## 安装说明
 
-            - **Windows**：下载 `codeswitch-amd64-installer.exe` 运行安装，或下载 `codeswitch.exe` 直接运行
-            - **macOS (Apple Silicon)**：下载 `codeswitch-macos-arm64.zip`
-            - **macOS (Intel)**：下载 `codeswitch-macos-amd64.zip`
+            - **Windows**：下载 `CodeTogether-amd64-installer.exe` 运行安装，或下载 `CodeTogether.exe` 直接运行
+            - **macOS (Apple Silicon)**：下载 `codetogether-macos-arm64.zip`
+            - **macOS (Intel)**：下载 `codetogether-macos-amd64.zip`
+
+            See [RELEASE_NOTES.md](https://github.com/genewoo/ai-together/blob/main/RELEASE_NOTES.md) for detailed changes.
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
Fixes critical path issues in `.github/workflows/release.yml` that would cause CI builds to fail.

## Changes

- Add `working-directory: ./member` to all build steps
- Update app bundle name: `codeswitch.app`/`CodeSwitch.app` → `CodeTogether.app`
- Update binary name: `CodeSwitch.exe` → `CodeTogether.exe`
- Update artifact paths: `bin/` → `member/bin/`
- Update archive names: `codeswitch-macos-*.zip` → `codetogether-macos-*.zip`
- Simplify release notes with link to `RELEASE_NOTES.md`

## Why This Is Needed

The existing workflow expected paths that don't exist in the monorepo structure:
- Expected `frontend/` at root, but it's at `member/frontend/`
- Expected `codeswitch.app` bundle, but actual output is `CodeTogether.app`
- Expected artifacts in `bin/`, but they're built in `member/bin/`

## Related

This should be merged before or together with #47 (RELEASE.md documentation), which references this workflow.