### PR TITLE
fix(integration): include password in PostgreSQL connection string

### DIFF
--- a/integration/cleanup.go
+++ b/integration/cleanup.go
@@ -39,8 +39,8 @@ func setupTestDB(logger *slog.Logger) string {
 	}
 
 	// Connect to postgres database to create test database
-	adminDBURL := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable",
-		connConfig.User, connConfig.Host, connConfig.Port, "postgres")
+	adminDBURL := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		connConfig.User, connConfig.Password, connConfig.Host, connConfig.Port, "postgres")
 
 	ctx := context.Background()
 	conn, err := pgx.Connect(ctx, adminDBURL)


### PR DESCRIPTION
Fixes #71

## Summary
Fixed PostgreSQL authentication failure in integration tests by including the password in the connection string when connecting to the `postgres` database.

## Problem
Integration tests were failing in GitHub Actions CI with the error:
```
FATAL: password authentication failed for user "postgres"
```

The bug was in `integration/cleanup.go` where the `adminDBURL` was constructed without the password component:
```go
adminDBURL := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable",
    connConfig.User, connConfig.Host, connConfig.Port, "postgres")
```

This resulted in a connection string like `postgres://username@host:port/database` (missing password).

## Solution
Updated the connection string construction to include the password from `connConfig.Password`:
```go
adminDBURL := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
    connConfig.User, connConfig.Password, connConfig.Host, connConfig.Port, "postgres")
```

This now correctly generates `postgres://username:password@host:port/database`.

## Changes
- **File:** `integration/cleanup.go` (lines 42-43)
- **Function:** `setupTestDB()`
- Added `connConfig.Password` parameter to the connection string format

## Testing
- Verified the fix by testing the database connection logic
- The connection string now includes both username and password
- This resolves the authentication failure in CI environments where PostgreSQL requires password authentication

## Impact
- **Breaking Changes:** None
- **Backward Compatibility:** Full - this only fixes a bug in how credentials were passed
- **Environment:** Fixes CI integration tests and any local setups requiring password authentication

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>