### PR TITLE
feat: auto-refresh team analytics every 30 seconds

### DIFF
--- a/manager/src/composables/useAutoRefresh.ts
+++ b/manager/src/composables/useAutoRefresh.ts
@@ -1,0 +1,59 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+/**
+ * Auto-refresh composable for analytics pages.
+ * Refreshes data at a fixed interval, pauses when the tab is hidden,
+ * and guards against stacking requests during loading.
+ *
+ * Per spec TA-04-102: team analytics should update every 30 seconds.
+ */
+export function useAutoRefresh(fetchFn: () => Promise<void>, isLoading: () => boolean, intervalMs = 30_000) {
+  const lastUpdated = ref<Date | null>(null)
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  async function tick() {
+    if (isLoading()) return
+    try {
+      await fetchFn()
+      lastUpdated.value = new Date()
+    } catch {
+      // errors are handled inside fetchFn already
+    }
+  }
+
+  function start() {
+    stop()
+    timer = setInterval(tick, intervalMs)
+  }
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Tab became visible — refresh immediately then resume interval
+      tick()
+      start()
+    } else {
+      stop()
+    }
+  }
+
+  onMounted(() => {
+    // First data load sets the initial timestamp
+    lastUpdated.value = new Date()
+    start()
+    document.addEventListener('visibilitychange', handleVisibility)
+  })
+
+  onUnmounted(() => {
+    stop()
+    document.removeEventListener('visibilitychange', handleVisibility)
+  })
+
+  return { lastUpdated, start, stop }
+}

--- a/manager/src/pages/TokenHistoryPage.vue
+++ b/manager/src/pages/TokenHistoryPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useAutoRefresh } from '../composables/useAutoRefresh'
 import dayjs from 'dayjs'
 import DateRangePicker from '../components/common/DateRangePicker.vue'
 import MultiSelect from '../components/common/MultiSelect.vue'
@@ -141,6 +142,8 @@ function handleExportJSON() {
   exportJSON(data.value.records, `token-history-${searchParams.value.startDate}-${searchParams.value.endDate}`)
 }
 
+const { lastUpdated } = useAutoRefresh(fetchData, () => isLoading.value)
+
 onMounted(() => {
   fetchFilterOptions()
   fetchData()
@@ -158,6 +161,12 @@ onMounted(() => {
         >
           ⟳ Refresh
         </button>
+        <span
+          v-if="lastUpdated"
+          class="text-xs text-gray-400 dark:text-gray-500 self-center whitespace-nowrap"
+        >
+          Updated {{ lastUpdated.toLocaleTimeString() }}
+        </span>
         <div class="relative">
           <button
             @click="showExportMenu = !showExportMenu"

--- a/manager/src/pages/TokenProviderPage.vue
+++ b/manager/src/pages/TokenProviderPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useAutoRefresh } from '../composables/useAutoRefresh'
 import dayjs from 'dayjs'
 import {
   Chart as ChartJS,
@@ -175,6 +176,8 @@ const pieOptions = {
   }
 }
 
+const { lastUpdated } = useAutoRefresh(fetchData, () => isLoading.value)
+
 onMounted(() => {
   fetchFilterOptions()
   fetchData()
@@ -192,6 +195,12 @@ onMounted(() => {
         >
           ⟳ Refresh
         </button>
+        <span
+          v-if="lastUpdated"
+          class="text-xs text-gray-400 dark:text-gray-500 self-center whitespace-nowrap"
+        >
+          Updated {{ lastUpdated.toLocaleTimeString() }}
+        </span>
         <div class="relative">
           <button
             @click="showExportMenu = !showExportMenu"

--- a/manager/src/pages/TokenUserPage.vue
+++ b/manager/src/pages/TokenUserPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useAutoRefresh } from '../composables/useAutoRefresh'
 import dayjs from 'dayjs'
 import {
   Chart as ChartJS,
@@ -146,6 +147,8 @@ const horizontalBarOptions = {
   }
 }
 
+const { lastUpdated } = useAutoRefresh(fetchData, () => isLoading.value)
+
 onMounted(() => {
   fetchFilterOptions()
   fetchData()
@@ -163,6 +166,12 @@ onMounted(() => {
         >
           ⟳ Refresh
         </button>
+        <span
+          v-if="lastUpdated"
+          class="text-xs text-gray-400 dark:text-gray-500 self-center whitespace-nowrap"
+        >
+          Updated {{ lastUpdated.toLocaleTimeString() }}
+        </span>
         <div class="relative">
           <button
             @click="showExportMenu = !showExportMenu"


### PR DESCRIPTION
## Summary

Closes #103

Adds automatic data refresh every 30 seconds to team analytics pages per spec TA-04-102.

### Changes

- **New  composable** (`manager/src/composables/useAutoRefresh.ts`)
  - 30-second auto-refresh interval
  - Pauses when tab is hidden (`document.visibilityState`)
  - Guards against stacking requests during loading
  - Exposes `lastUpdated` timestamp for UI indicator

- **Applied to 3 pages:**
  - Provider Analytics (`TokenProviderPage.vue`)
  - User Analytics (`TokenUserPage.vue`)
  - Token History (`TokenHistoryPage.vue`)
  - Each shows a subtle "Updated HH:MM:SS" label next to the Refresh button

### Behavior

- Data refreshes automatically every 30s
- When tab becomes hidden → interval pauses
- When tab becomes visible → immediate refresh + resume interval
- Manual Refresh button still works (triggers `fetchData` directly)
- No duplicate requests when a refresh is already in flight