### PR TITLE
fix: classify password change errors correctly

### DIFF
--- a/server/handlers/auth_handler.go
+++ b/server/handlers/auth_handler.go
@@ -15,6 +15,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -509,10 +510,18 @@ func (h *AuthHandler) ChangePassword(c *gin.Context) {
 	err := h.userService.ChangePassword(authenticatedUser.ID, req.CurrentPassword, req.NewPassword)
 	if err != nil {
 		requestID := c.GetString("request_id")
+		if errors.Is(err, services.ErrIncorrectPassword) {
+			c.JSON(http.StatusBadRequest, models.ErrorResponse{
+				Error:   err.Error(),
+				Code:    models.ErrCodeValidation,
+				Request: requestID,
+			})
+			return
+		}
 		log.Printf("[ERROR] [%s] Failed to change password - user_id=%d error=%v", requestID, authenticatedUser.ID, err)
-		c.JSON(http.StatusBadRequest, models.ErrorResponse{
-			Error:   err.Error(),
-			Code:    models.ErrCodeValidation,
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "Failed to change password",
+			Code:    models.ErrCodeInternal,
 			Request: requestID,
 		})
 		return

--- a/server/handlers/auth_handler_mock_test.go
+++ b/server/handlers/auth_handler_mock_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"switch-server/models"
+	"switch-server/services"
 )
 
 // MockUserService is a mock implementation of UserServiceInterface using testify/mock
@@ -1291,7 +1292,7 @@ func TestChangePassword_WrongCurrentPassword(t *testing.T) {
 	mockTeamService := new(MockTeamService)
 
 	testUser := createTestUser(1, "test@example.com", "Test User", "manager", 1)
-	mockService.On("ChangePassword", int64(1), "wrongPass", "newPass456").Return(assert.AnError)
+	mockService.On("ChangePassword", int64(1), "wrongPass", "newPass456").Return(services.ErrIncorrectPassword)
 
 	handler := NewAuthHandler(mockService, mockTeamService)
 
@@ -1314,6 +1315,39 @@ func TestChangePassword_WrongCurrentPassword(t *testing.T) {
 	var response map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &response)
 	assert.Equal(t, "VALIDATION_ERROR", response["code"])
+
+	mockService.AssertExpectations(t)
+}
+
+func TestChangePassword_InternalError(t *testing.T) {
+	mockService := new(MockUserService)
+	mockTeamService := new(MockTeamService)
+
+	testUser := createTestUser(1, "test@example.com", "Test User", "manager", 1)
+	mockService.On("ChangePassword", int64(1), "oldPass123", "newPass456").Return(assert.AnError)
+
+	handler := NewAuthHandler(mockService, mockTeamService)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.PUT("/password", func(c *gin.Context) {
+		c.Set("user", testUser)
+		handler.ChangePassword(c)
+	})
+
+	reqBody := `{"current_password": "oldPass123", "new_password": "newPass456"}`
+	req, _ := http.NewRequest("PUT", "/password", bytes.NewReader([]byte(reqBody)))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Equal(t, "INTERNAL_ERROR", response["code"])
+	assert.Equal(t, "Failed to change password", response["error"])
 
 	mockService.AssertExpectations(t)
 }

--- a/server/services/user_service.go
+++ b/server/services/user_service.go
@@ -16,12 +16,16 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
 	"switch-server/models"
 	"switch-server/repository"
 )
+
+// ErrIncorrectPassword is returned when the current password doesn't match.
+var ErrIncorrectPassword = errors.New("current password is incorrect")
 
 type UserService struct {
 	userRepo repository.UserRepositoryInterface
@@ -170,7 +174,7 @@ func (s *UserService) ChangePassword(userID int64, currentPassword, newPassword 
 	}
 
 	if !s.ValidatePassword(user, currentPassword) {
-		return fmt.Errorf("current password is incorrect")
+		return ErrIncorrectPassword
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)

--- a/server/services/user_service_test.go
+++ b/server/services/user_service_test.go
@@ -15,6 +15,7 @@
 package services
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -516,7 +517,7 @@ func TestUserService_ChangePassword_WrongCurrentPassword(t *testing.T) {
 	err = service.ChangePassword(1, "wrongPassword", "newPassword456")
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "current password is incorrect")
+	assert.True(t, errors.Is(err, ErrIncorrectPassword), "expected ErrIncorrectPassword")
 
 	mockRepo.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

ChangePassword handler was returning `400 VALIDATION_ERROR` for **all** service errors, including database failures and bcrypt hash errors. This made it impossible for clients and monitoring to distinguish a wrong current password from a server-side failure.

## Changes

- **Service layer**: Introduced sentinel error `ErrIncorrectPassword` in `services/user_service.go`
- **Handler**: Uses `errors.Is()` to classify:
  - Wrong current password → `400 VALIDATION_ERROR` (validation)
  - DB/hash/other failures → `500 INTERNAL_ERROR` (internal)
- **Tests**: Updated existing wrong-password test to use sentinel; added new `TestChangePassword_InternalError` handler test

Fixes #125