### PR TITLE
fix: login error message disappears after wrong credentials

### DIFF
--- a/manager/src/api/client.ts
+++ b/manager/src/api/client.ts
@@ -31,6 +31,11 @@ apiClient.interceptors.response.use(
 
     // Handle 401 Unauthorized
     if (error.response?.status === 401 && originalRequest) {
+      // Don't intercept 401 from login — it means wrong credentials, not expired token
+      if (originalRequest.url?.includes('/auth/login')) {
+        return Promise.reject(error)
+      }
+
       const refreshToken = localStorage.getItem('refresh_token')
 
       if (refreshToken && !originalRequest.url?.includes('/auth/refresh')) {


### PR DESCRIPTION
## Summary

Skip the 401 interceptor for the login endpoint (). A 401 from login means **wrong credentials**, not an expired session — the interceptor was redirecting to  and wiping the Vue component's error state.

## Fix

Added an early return in the 401 handler that lets the error propagate to the login form when the request URL includes .

Fixes #129