### PR TITLE
fix: add tenant isolation checks to all team membership endpoints (#78)

### DIFF
--- a/server/handlers/team_handler.go
+++ b/server/handlers/team_handler.go
@@ -253,6 +253,34 @@ func (h *TeamHandler) ListTeamMembers(c *gin.Context) {
 		return
 	}
 
+	// Verify tenant ownership
+	team, err := h.teamService.GetTeamByID(teamID)
+	if err != nil || team == nil {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error: "Team not found",
+			Code:  models.ErrCodeNotFound,
+		})
+		return
+	}
+
+	user, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, models.ErrorResponse{
+			Error: "User not found in context",
+			Code:  models.ErrCodeUnauthorized,
+		})
+		return
+	}
+	currentUser := user.(*models.User)
+
+	if team.TenantID != currentUser.TenantID {
+		c.JSON(http.StatusForbidden, models.ErrorResponse{
+			Error: "Team not found",
+			Code:  models.ErrCodeNotFound,
+		})
+		return
+	}
+
 	// Get team members from the service
 	members, err := h.teamService.GetTeamMembers(teamID)
 	if err != nil {
@@ -298,6 +326,14 @@ func (h *TeamHandler) AddTeamMember(c *gin.Context) {
 	team, err := h.teamService.GetTeamByID(teamID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error: "Team not found",
+			Code:  models.ErrCodeNotFound,
+		})
+		return
+	}
+
+	if team.TenantID != currentUser.TenantID {
+		c.JSON(http.StatusForbidden, models.ErrorResponse{
 			Error: "Team not found",
 			Code:  models.ErrCodeNotFound,
 		})
@@ -353,7 +389,15 @@ func (h *TeamHandler) AddTeamMember(c *gin.Context) {
 		return
 	}
 
-	// If user already exists, add them to the team
+	// If user already exists, reject cross-tenant user addition
+	if existingUser.TenantID != currentUser.TenantID {
+		c.JSON(http.StatusForbidden, models.ErrorResponse{
+			Error: "Cannot add users from other tenants to this team",
+			Code:  models.ErrCodeForbidden,
+		})
+		return
+	}
+
 	err = h.teamService.AddTeamMember(teamID, existingUser.ID, req.Role)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to add team member: " + err.Error()})
@@ -439,6 +483,14 @@ func (h *TeamHandler) RemoveTeamMember(c *gin.Context) {
 		return
 	}
 
+	if team.TenantID != currentUser.TenantID {
+		c.JSON(http.StatusForbidden, models.ErrorResponse{
+			Error: "Team not found",
+			Code:  models.ErrCodeNotFound,
+		})
+		return
+	}
+
 	if team.OwnerID != currentUser.ID {
 		c.JSON(http.StatusForbidden, models.ErrorResponse{
 			Error: "You don't have permission to remove members from this team",
@@ -471,10 +523,35 @@ func (h *TeamHandler) GetTeamSettings(c *gin.Context) {
 		return
 	}
 
-	// In a real application, get team settings from the database
-	// For now, return empty settings
-	settings := make(map[string]string)
-	c.JSON(http.StatusOK, gin.H{"team_id": teamID, "settings": settings})
+	// Verify tenant ownership
+	team, err := h.teamService.GetTeamByID(teamID)
+	if err != nil || team == nil {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error: "Team not found",
+			Code:  models.ErrCodeNotFound,
+		})
+		return
+	}
+
+	user, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, models.ErrorResponse{
+			Error: "User not found in context",
+			Code:  models.ErrCodeUnauthorized,
+		})
+		return
+	}
+	currentUser := user.(*models.User)
+
+	if team.TenantID != currentUser.TenantID {
+		c.JSON(http.StatusForbidden, models.ErrorResponse{
+			Error: "Team not found",
+			Code:  models.ErrCodeNotFound,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"team_id": teamID, "settings": team.Settings})
 }
 
 func (h *TeamHandler) UpdateTeamSettings(c *gin.Context) {
@@ -512,6 +589,14 @@ func (h *TeamHandler) UpdateTeamSettings(c *gin.Context) {
 	team, err := h.teamService.GetTeamByID(teamID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error: "Team not found",
+			Code:  models.ErrCodeNotFound,
+		})
+		return
+	}
+
+	if team.TenantID != currentUser.TenantID {
+		c.JSON(http.StatusForbidden, models.ErrorResponse{
 			Error: "Team not found",
 			Code:  models.ErrCodeNotFound,
 		})

--- a/server/handlers/team_handler_test.go
+++ b/server/handlers/team_handler_test.go
@@ -222,11 +222,13 @@ func TestTeamHandler_ListTeamMembers_Success(t *testing.T) {
 	mockLicenseService := new(MockLicenseService)
 	mockUserService := new(MockUserService)
 
+	team := &models.Team{ID: 1, Name: "Team", OwnerID: 1, TenantID: 1}
 	members := []models.User{
 		*createTestUser(2, "member1@example.com", "Member 1", "member", 1),
 		*createTestUser(3, "member2@example.com", "Member 2", "member", 1),
 	}
 
+	mockTeamService.On("GetTeamByID", int64(1)).Return(team, nil)
 	mockTeamService.On("GetTeamMembers", int64(1)).Return(members, nil)
 
 	handler := NewTeamHandler(mockTeamService, mockUserService, mockLicenseService, testJWTSecret)
@@ -429,6 +431,9 @@ func TestTeamHandler_GetTeamSettings_Success(t *testing.T) {
 	mockLicenseService := new(MockLicenseService)
 	mockUserService := new(MockUserService)
 
+	team := &models.Team{ID: 1, Name: "Team", OwnerID: 1, TenantID: 1}
+	mockTeamService.On("GetTeamByID", int64(1)).Return(team, nil)
+
 	handler := NewTeamHandler(mockTeamService, mockUserService, mockLicenseService, testJWTSecret)
 	router := setupTeamRouter(handler)
 
@@ -545,4 +550,148 @@ func setupTeamRouter(handler *TeamHandler) *gin.Engine {
 	router.PUT("/teams/:id/settings", handler.UpdateTeamSettings)
 
 	return router
+}
+
+// --- Cross-tenant regression tests for #78 ---
+
+func TestTeamHandler_ListTeamMembers_CrossTenant(t *testing.T) {
+	mockTeamService := new(MockTeamService)
+	mockLicenseService := new(MockLicenseService)
+
+	// Team belongs to tenant 2, user belongs to tenant 1
+	team := &models.Team{ID: 1, Name: "Other Tenant Team", OwnerID: 1, TenantID: 2}
+	mockTeamService.On("GetTeamByID", int64(1)).Return(team, nil)
+
+	handler := NewTeamHandler(mockTeamService, nil, mockLicenseService, testJWTSecret)
+	router := setupTeamRouter(handler)
+
+	testUser := createTestUser(1, "user@example.com", "User", "manager", 1) // TenantID: 1
+
+	req, _ := http.NewRequest("GET", "/teams/1/members", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, setUserContext(req, testUser))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	mockTeamService.AssertExpectations(t)
+}
+
+func TestTeamHandler_AddTeamMember_CrossTenantTeam(t *testing.T) {
+	mockTeamService := new(MockTeamService)
+	mockLicenseService := new(MockLicenseService)
+	mockUserService := new(MockUserService)
+
+	// Team belongs to tenant 2
+	team := &models.Team{ID: 1, Name: "Other Tenant Team", OwnerID: 1, TenantID: 2}
+	mockTeamService.On("GetTeamByID", int64(1)).Return(team, nil)
+
+	handler := NewTeamHandler(mockTeamService, mockUserService, mockLicenseService, testJWTSecret)
+	router := setupTeamRouter(handler)
+
+	testUser := createTestUser(1, "user@example.com", "User", "manager", 1) // TenantID: 1
+
+	reqBody := AddMemberRequest{Email: "member@example.com", Role: "member"}
+	body, _ := json.Marshal(reqBody)
+	req, _ := http.NewRequest("POST", "/teams/1/members", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, setUserContext(req, testUser))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	mockTeamService.AssertExpectations(t)
+}
+
+func TestTeamHandler_AddTeamMember_CrossTenantUser(t *testing.T) {
+	mockTeamService := new(MockTeamService)
+	mockLicenseService := new(MockLicenseService)
+	mockUserService := new(MockUserService)
+
+	// Team and user are in tenant 1, but invited user is in tenant 2
+	team := &models.Team{ID: 1, Name: "Team", OwnerID: 1, TenantID: 1}
+	existingUser := createTestUser(2, "other@example.com", "Other User", "member", 2) // TenantID: 2
+
+	mockTeamService.On("GetTeamByID", int64(1)).Return(team, nil)
+	mockUserService.On("GetUserByEmail", "other@example.com").Return(existingUser, nil)
+
+	handler := NewTeamHandler(mockTeamService, mockUserService, mockLicenseService, testJWTSecret)
+	router := setupTeamRouter(handler)
+
+	testUser := createTestUser(1, "user@example.com", "User", "manager", 1)
+
+	reqBody := AddMemberRequest{Email: "other@example.com", Role: "member"}
+	body, _ := json.Marshal(reqBody)
+	req, _ := http.NewRequest("POST", "/teams/1/members", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, setUserContext(req, testUser))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Cannot add users from other tenants")
+	mockTeamService.AssertExpectations(t)
+	mockUserService.AssertExpectations(t)
+}
+
+func TestTeamHandler_RemoveTeamMember_CrossTenant(t *testing.T) {
+	mockTeamService := new(MockTeamService)
+	mockLicenseService := new(MockLicenseService)
+
+	team := &models.Team{ID: 1, Name: "Other Tenant Team", OwnerID: 1, TenantID: 2}
+	mockTeamService.On("GetTeamByID", int64(1)).Return(team, nil)
+
+	handler := NewTeamHandler(mockTeamService, nil, mockLicenseService, testJWTSecret)
+	router := setupTeamRouter(handler)
+
+	testUser := createTestUser(1, "user@example.com", "User", "manager", 1) // TenantID: 1
+
+	req, _ := http.NewRequest("DELETE", "/teams/1/members/2", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, setUserContext(req, testUser))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	mockTeamService.AssertExpectations(t)
+}
+
+func TestTeamHandler_GetTeamSettings_CrossTenant(t *testing.T) {
+	mockTeamService := new(MockTeamService)
+	mockLicenseService := new(MockLicenseService)
+
+	team := &models.Team{ID: 1, Name: "Other Tenant Team", OwnerID: 1, TenantID: 2}
+	mockTeamService.On("GetTeamByID", int64(1)).Return(team, nil)
+
+	handler := NewTeamHandler(mockTeamService, nil, mockLicenseService, testJWTSecret)
+	router := setupTeamRouter(handler)
+
+	testUser := createTestUser(1, "user@example.com", "User", "manager", 1) // TenantID: 1
+
+	req, _ := http.NewRequest("GET", "/teams/1/settings", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, setUserContext(req, testUser))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	mockTeamService.AssertExpectations(t)
+}
+
+func TestTeamHandler_UpdateTeamSettings_CrossTenant(t *testing.T) {
+	mockTeamService := new(MockTeamService)
+	mockLicenseService := new(MockLicenseService)
+
+	team := &models.Team{ID: 1, Name: "Other Tenant Team", OwnerID: 1, TenantID: 2}
+	mockTeamService.On("GetTeamByID", int64(1)).Return(team, nil)
+
+	handler := NewTeamHandler(mockTeamService, nil, mockLicenseService, testJWTSecret)
+	router := setupTeamRouter(handler)
+
+	testUser := createTestUser(1, "user@example.com", "User", "manager", 1) // TenantID: 1
+
+	settings := map[string]string{"key": "value"}
+	body, _ := json.Marshal(settings)
+	req, _ := http.NewRequest("PUT", "/teams/1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, setUserContext(req, testUser))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	mockTeamService.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

Closes #78

Team membership and settings endpoints allowed cross-tenant access — any authenticated user could list members of teams in other tenants, and managers could invite users across tenant boundaries.

## Changes

- **ListTeamMembers**: Added tenant ownership check (was completely unprotected)
- **AddTeamMember**: Added tenant check on the team + reject adding users from other tenants
- **RemoveTeamMember**: Added tenant ownership check
- **GetTeamSettings**: Added tenant ownership check (was completely unprotected)
- **UpdateTeamSettings**: Added tenant ownership check
- **6 new cross-tenant regression tests** covering all five endpoints

## Test Results

- All unit tests pass (gofmt clean, build clean)