### PR TITLE
feat: license-gated feature visibility in manager UI (#106)

### DIFF
--- a/manager/src/api/license.ts
+++ b/manager/src/api/license.ts
@@ -1,0 +1,41 @@
+import { apiClient } from './client'
+
+export interface LicenseInfo {
+  customer_name: string | null
+  license_id: string | null
+  type: string
+  type_name: string
+  max_seats: number
+  max_teams: number
+  data_retention_days: number
+  issued_at: string | null
+  expires_at: string | null
+}
+
+export interface LicenseUsage {
+  current_users: number
+  current_teams: number
+  teams_remaining: number
+  provider_counts: Record<string, number>
+}
+
+export interface LicenseStatus {
+  has_active_license: boolean
+  days_remaining: number
+  is_using_defaults?: boolean
+  can_add_user: boolean
+  can_add_provider: Record<string, boolean>
+  can_create_team: boolean
+}
+
+export interface LicenseResponse {
+  license: LicenseInfo
+  usage: LicenseUsage
+  status: LicenseStatus
+}
+
+export const licenseApi = {
+  getLicense() {
+    return apiClient.get<LicenseResponse>('/api/v1/license')
+  },
+}

--- a/manager/src/components/layout/Sidebar.vue
+++ b/manager/src/components/layout/Sidebar.vue
@@ -1,34 +1,50 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../../stores/auth'
+import { useLicenseStore } from '../../stores/license'
 
 interface NavItem {
   label: string
   path: string
   icon: string
   adminOnly?: boolean
+  requiresCommercial?: boolean
 }
 
 const navItems: NavItem[] = [
   { label: 'Dashboard', path: '/', icon: 'dashboard' },
   { label: 'Personal Analytics', path: '/analytics/personal', icon: 'personal' },
-  { label: 'Provider Stats', path: '/analytics/providers', icon: 'storage', adminOnly: true },
-  { label: 'User Stats', path: '/analytics/users', icon: 'chart', adminOnly: true },
-  { label: 'History', path: '/analytics/history', icon: 'history', adminOnly: true },
+  { label: 'Provider Stats', path: '/analytics/providers', icon: 'storage', adminOnly: true, requiresCommercial: true },
+  { label: 'User Stats', path: '/analytics/users', icon: 'chart', adminOnly: true, requiresCommercial: true },
+  { label: 'History', path: '/analytics/history', icon: 'history', adminOnly: true, requiresCommercial: true },
   { label: 'Users', path: '/users', icon: 'users', adminOnly: true },
 ]
 
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
+const licenseStore = useLicenseStore()
+
+const showUpgradeModal = ref(false)
+
+// Show upgrade modal if navigated with licenseRequired query
+onMounted(() => {
+  if (route.query.licenseRequired) {
+    showUpgradeModal.value = true
+  }
+})
 
 const filteredItems = computed(() => {
   return navItems.filter(item => !item.adminOnly || authStore.isAdmin)
 })
 
-function navigate(path: string) {
-  router.push(path)
+function navigate(item: NavItem) {
+  if (item.requiresCommercial && !licenseStore.hasActiveLicense) {
+    showUpgradeModal.value = true
+    return
+  }
+  router.push(item.path)
 }
 
 function isActive(path: string): boolean {
@@ -43,6 +59,7 @@ const icons: Record<string, string> = {
   chart: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />',
   history: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />',
   users: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />',
+  lock: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />',
 }
 </script>
 
@@ -52,16 +69,71 @@ const icons: Record<string, string> = {
       <button
         v-for="item in filteredItems"
         :key="item.path"
-        @click="navigate(item.path)"
+        @click="navigate(item)"
         class="w-full flex items-center px-4 py-3 rounded-lg transition-colors"
         :class="{
           'bg-blue-600 text-white': isActive(item.path),
-          'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800': !isActive(item.path)
+          'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800': !isActive(item.path) && !(item.requiresCommercial && !licenseStore.hasActiveLicense),
+          'text-gray-400 dark:text-gray-500 cursor-pointer': item.requiresCommercial && !licenseStore.hasActiveLicense && !isActive(item.path),
         }"
       >
-        <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" v-html="icons[item.icon]"></svg>
-        <span class="font-medium">{{ item.label }}</span>
+        <svg class="w-5 h-5 mr-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" v-html="icons[item.icon]"></svg>
+        <span class="font-medium flex-1 text-left">{{ item.label }}</span>
+        <svg
+          v-if="item.requiresCommercial && !licenseStore.hasActiveLicense"
+          class="w-4 h-4 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          v-html="icons.lock"
+        ></svg>
       </button>
     </div>
+
+    <!-- Upgrade Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showUpgradeModal"
+        class="fixed inset-0 z-50 flex items-center justify-center"
+      >
+        <div class="fixed inset-0 bg-black/50" @click="showUpgradeModal = false"></div>
+        <div class="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full mx-4 p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <div class="w-10 h-10 bg-amber-100 dark:bg-amber-900/30 rounded-full flex items-center justify-center">
+              <svg class="w-5 h-5 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+            </div>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Commercial License Required</h3>
+          </div>
+          <p class="text-gray-600 dark:text-gray-400 mb-4">
+            This feature requires a commercial license. Upgrade to unlock team analytics, cost tracking, request history, and more.
+          </p>
+          <ul class="text-sm text-gray-500 dark:text-gray-400 mb-6 space-y-1">
+            <li>✅ Team analytics dashboard</li>
+            <li>✅ Provider performance metrics</li>
+            <li>✅ Request history with pagination</li>
+            <li>✅ 90-day data retention</li>
+            <li>✅ Multi-team support</li>
+          </ul>
+          <div class="flex gap-3">
+            <button
+              @click="showUpgradeModal = false"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 dark:bg-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+            >
+              Close
+            </button>
+            <a
+              href="https://ai-together.dev/pricing"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex-1 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors text-center"
+            >
+              Learn More
+            </a>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </nav>
 </template>

--- a/manager/src/router/index.ts
+++ b/manager/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import type { RouteRecordRaw, RouteLocationNormalized } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { useSetupStore } from '../stores/setup'
+import { useLicenseStore } from '../stores/license'
 
 // Layouts
 import AppLayout from '../components/layout/AppLayout.vue'
@@ -53,19 +54,19 @@ const routes: RouteRecordRaw[] = [
         path: 'analytics/providers',
         name: 'analytics-providers',
         component: TokenProviderPage,
-        meta: { requiresAdmin: true },
+        meta: { requiresAdmin: true, requiresCommercial: true, commercialLabel: 'Team Analytics' },
       },
       {
         path: 'analytics/users',
         name: 'analytics-users',
         component: TokenUserPage,
-        meta: { requiresAdmin: true },
+        meta: { requiresAdmin: true, requiresCommercial: true, commercialLabel: 'User Rankings' },
       },
       {
         path: 'analytics/history',
         name: 'analytics-history',
         component: TokenHistoryPage,
-        meta: { requiresAdmin: true },
+        meta: { requiresAdmin: true, requiresCommercial: true, commercialLabel: 'Request History' },
       },
       {
         path: 'users',
@@ -119,9 +120,20 @@ router.beforeEach(async (to: RouteLocationNormalized) => {
     return { name: 'login', query: { redirect: to.fullPath } }
   }
 
+  // Initialize license store (only after auth is confirmed)
+  const licenseStore = useLicenseStore()
+  if (!licenseStore.isInitialized) {
+    await licenseStore.initialize()
+  }
+
   // Admin-only routes
   if (to.meta.requiresAdmin && !authStore.isAdmin) {
     return { name: 'dashboard' }
+  }
+
+  // Commercial-only routes
+  if (to.meta.requiresCommercial && !licenseStore.hasActiveLicense) {
+    return { name: 'dashboard', query: { licenseRequired: to.meta.commercialLabel as string || 'Commercial' } }
   }
 
   return

--- a/manager/src/stores/license.ts
+++ b/manager/src/stores/license.ts
@@ -1,0 +1,49 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { licenseApi } from '../api/license'
+import { getErrorMessage } from '../api/client'
+
+export const useLicenseStore = defineStore('license', () => {
+  const hasActiveLicense = ref(false)
+  const isInitialized = ref(false)
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  const licenseType = ref<string>('open_source')
+  const daysRemaining = ref(0)
+  const canCreateTeam = ref(true)
+
+  async function fetchLicense() {
+    isLoading.value = true
+    error.value = null
+    try {
+      const response = await licenseApi.getLicense()
+      hasActiveLicense.value = response.data.status.has_active_license
+      licenseType.value = response.data.license.type
+      daysRemaining.value = response.data.status.days_remaining
+      canCreateTeam.value = response.data.status.can_create_team
+    } catch (err) {
+      error.value = getErrorMessage(err)
+      // Default to open source on error
+      hasActiveLicense.value = false
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function initialize() {
+    await fetchLicense()
+    isInitialized.value = true
+  }
+
+  return {
+    hasActiveLicense,
+    isInitialized,
+    isLoading,
+    error,
+    licenseType,
+    daysRemaining,
+    canCreateTeam,
+    fetchLicense,
+    initialize,
+  }
+})


### PR DESCRIPTION
## Summary

Closes #106

Commercial-only features now appear as locked/grayed-out in the sidebar with a lock icon. Clicking shows an upgrade modal. Direct URL navigation is blocked by the router guard.

## Commercial-only features (per EARS LC-01-301~308)

- Provider Stats (team analytics)
- User Stats (user rankings)
- History (request history with pagination)

## Changes

- **License API client** (`api/license.ts`) — typed interface for `GET /api/v1/license`
- **License Pinia store** (`stores/license.ts`) — fetches and caches `hasActiveLicense`
- **Router guard** — `requiresCommercial` meta redirects to dashboard with upgrade modal trigger
- **Sidebar** — lock icon on commercial items, grayed-out styling, upgrade modal on click
- **Upgrade modal** — lists commercial benefits with "Learn More" CTA

## Test Results

- `vue-tsc --noEmit` clean ✅
- `eslint` — no new warnings/errors ✅